### PR TITLE
Beating back file bloat

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
                 </span>
 
                 <span class="row">
-                    <label for="paper_rotation_90">Rotate Paper 90° <input type="checkbox" name="paper_rotation_90"></label>
+                    <label for="paper_rotation_90">Rotate Paper 90° <input type="checkbox" name="paper_rotation_90" id="paper_rotation_90"></label>
                     <span data-balloon-length="medium" aria-label="This puts your paper in 'landscape' -- layout still happens the same, but the porportions of things will be different" data-balloon-pos="up">ℹ️</span>
                 </span>
 
@@ -152,8 +152,8 @@
                     </select>
                 </span>
 
-                <span class="row"> <label for="page_scaling">Page Positioning</label>
-                    <select name="page_positioning" id="page_scaling">
+                <span class="row"> <label for="page_positioning">Page Positioning</label>
+                    <select name="page_positioning" id="page_positioning">
                         <option value="centered" selected>Centered</option>
                         <option value="binding_alinged">Snug against binding edge</option>
                     </select>


### PR DESCRIPTION
[THIS LINK HERE](https://htmlpreview.github.io/?https://github.com/momijizukamori/bookbinder-js/blob/six_partial_size_fix/index.html) should let you test the PR out

Always be learning....

Obviously I've only a hazy understanding of how this PDF library works (or PDFs work at all) but am getting there... slowly

**SO** 

In the last big PR/change, we shredded the original PDF uploaded and piece it back together with the correct page rotations before we hit the layout step. This increased file bloat. I've beaten that part back (am getting comparable file sizes now to pre-rotation changes) but there's more cleaning up we need to do with how we actually lay out the pages. 

I advocate landing THIS PR and I'll keep working on tightening it up in another one. 

The **incorrect** thing ~~we were~~ I was doing was in `createpages()` -- calling `embedPage` for each signature in the document. This apparently carries with it a lot of overhead (when done multiple times for a single PDF)  -- this would have been fine when signatures were just their own PDFs, that makes sense, but the aggregatePDF picks up bloat.  We should be embedding 'em all in one go with `embedPdf` (presumably reducing duplicate meta info or embedded font info or ?? stuff) Also, I imagine the wackies are doing it wrong as well (haven't pinned down that code yet) 

I think we need to tighten this up on all the pages we render onto -- we're calling `outPDF.embedPdf` in `writepages` for example, which is called multiple times. Need to wrestle with structure though to get correct references embedded and then passed around... which I'll do... later




+ PR comes with bonus HTML tweak because apparently I botch my positioning forms? 🤦‍♀️  (how did I ever think that worked?)