### PR TITLE
Restructuring Aggregate & Signature PDF generation/page embedding

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,13 @@
                     </select>
                     <span data-balloon-length="medium" aria-label="Duplex will alternate front and backs of sheets in a single file; Single-sided will split fronts and backs into seperate files." data-balloon-pos="up">ℹ️</span>
                 </span>
+                <span class="row"><label for="print_file">Print File</label>
+                    <select name="print_file" id="print_file">
+                        <option value="aggregated">Aggregated File Only</option>
+                        <option value="both" selected>Both aggregated & per signature files</option>
+                        <option value="signatures">Signature Files Only</option>
+                    </select>
+                </span>
 
                 <span class="row">
                     <label for="paper_rotation_90">Rotate Paper 90° <input type="checkbox" name="paper_rotation_90" id="paper_rotation_90"></label>

--- a/index.html
+++ b/index.html
@@ -332,7 +332,7 @@
                 <h2>Signature Info</h2>
 
                 <button type="button" name="preview" id="preview" disabled>Preview Output</button>
-                 <sub>(Duplex-only right now, not tested in all browsers)</sub><BR>
+                <span data-balloon-length="medium" aria-label="Will not show previews if 'Signature Files Only' is selected. Only shows one side for 'Single Sided' printing. Not tested on all browsers (or any browsers other than Chrome really...)" data-balloon-pos="up">ℹ️</span>
                 <center>
                     <iframe id="pdf" style="width: 100%; height: 10px;display:none;"></iframe>
                 </center>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,8 @@
             A Javascript-based app for formatting PDFs for bookbinding. For more information, feature requests, or to
             contribute, view the project's <a href="https://github.com/momijizukamori/bookbinder-js">Github repository</a>.
             If you have issues with this version, you can try the <a href="old/">old version</a> instead, which only supports folio layouts.
+            <center style="font-family:monospace;
+    padding-top: 0.75em;font-variant-caps: small-caps;">current version: 1.0.0</center>
         </div>
         <form id="bookbinder" name="bookbinder">
             <div class="section" id="input">
@@ -99,14 +101,6 @@
                     </select>
                     <span data-balloon-length="medium" aria-label="Duplex will alternate front and backs of sheets in a single file; Single-sided will split fronts and backs into seperate files." data-balloon-pos="up">ℹ️</span>
                 </span>
-                <span class="row"><label for="print_file">Print File</label>
-                    <select name="print_file" id="print_file">
-                        <option value="aggregated">Aggregated File Only</option>
-                        <option value="both" selected>Both aggregated & per signature files</option>
-                        <option value="signatures">Signature Files Only</option>
-                    </select>
-                </span>
-
                 <span class="row">
                     <label for="paper_rotation_90">Rotate Paper 90° <input type="checkbox" name="paper_rotation_90" id="paper_rotation_90"></label>
                     <span data-balloon-length="medium" aria-label="This puts your paper in 'landscape' -- layout still happens the same, but the porportions of things will be different" data-balloon-pos="up">ℹ️</span>
@@ -181,6 +175,15 @@
                     Top Margin: <input type="number" id="top_edge_padding_pt" name="top_edge_padding_pt" style="width: 5em;margin-left: 15px;"> pt<BR>
                     Bottom Margin: <input type="number" id="bottom_edge_padding_pt" name="bottom_edge_padding_pt" style="width: 5em;margin-left: 15px;"> pt<BR>
                 </span>
+
+                <span class="row"><label for="print_file">Downloaded File(s)</label>
+                    <select name="print_file" id="print_file">
+                        <option value="aggregated">Aggregated File Only</option>
+                        <option value="both" selected>Both aggregated & per signature files</option>
+                        <option value="signatures">Signature Files Only</option>
+                    </select>
+                </span>
+
 
             </div>
 

--- a/preload.js
+++ b/preload.js
@@ -73,7 +73,6 @@ class Book {
     }
 
     update(form) {
-
         this.duplex = form.get('printer_type') == 'duplex';
         this.duplexrotate = form.has('rotate_page');
         this.paper_rotation_90 = form.has('paper_rotation_90');
@@ -83,7 +82,7 @@ class Book {
         }
 
         this.source_rotation = form.get("source_rotation");
-        
+
         this.print_file = form.get("print_file");
         this.page_scaling = form.get("page_scaling");
         this.page_positioning = form.get("page_positioning");
@@ -127,6 +126,9 @@ class Book {
         return (isNaN(num)) ? 0 : num;
     }
 
+    /**
+     * Populates [this.currentdoc] from user's file system
+     */
     async openpdf(file) {
         this.inputpdf = file.name;
         this.input = await file.arrayBuffer(); //fs.readFileSync(filepath);
@@ -158,6 +160,9 @@ class Book {
 
     }
 
+    /**
+     * Populates [this.orderedpages] (array [0, 1, ... this.page_sheets * # of sheets]) 
+     */
     createpagelist() {
         this.pagecount = (this.managedDoc == null) ? this.currentdoc.getPageCount() : this.managedDoc.getPageCount();
         this.orderedpages = Array.from({ length: this.pagecount }, (x, i) => i);
@@ -187,11 +192,14 @@ class Book {
         console.log("Calculated pagecount [",this.pagecount,"] and ordered pages: ", this.orderedpages)
     }
 
+    /**
+     * Populates [this.managedDoc] with potentially rotated pages
+     *  & populates [this.book] with the correct Book instance
+     */
     async createpages() {
         this.createpagelist();
-        this.managedDoc = await pdf_lib__WEBPACK_IMPORTED_MODULE_0__.PDFDocument.create()
-        var pageNumbers = Array.from(Array(this.currentdoc.getPageCount()).keys())
-        let pages = await this.managedDoc.embedPdf(this.currentdoc, pageNumbers);
+        let pages;
+        [this.managedDoc, pages] = await this.embedPagesInNewPdf(this.currentdoc)
 
         for (var i = 0; i < pages.length; ++i) {
             var page = pages[i]
@@ -250,6 +258,8 @@ class Book {
     }
 
     /**
+     * Calls the appropriate builder basec on [this.format]
+     *  to generate PDF & populate Previewer
      * @param isPreview - if it's true we only generate preview content, if it's not true... we still 
      *      generate preview content AND a downloadable zip
      */
@@ -279,17 +289,23 @@ class Book {
                 fileList: this.filelist
             });
         } else if (this.format == 'standardsig' || this.format == 'customsig') {
-            const aggregatePdf = (this.print_file != "signatures") ? await pdf_lib__WEBPACK_IMPORTED_MODULE_0__.PDFDocument.create() : null;
-            var pageNumbers = Array.from(Array(this.managedDoc.getPageCount()).keys())
-            let embeddedPages = (this.print_file != "signatures") ? await aggregatePdf.embedPdf(this.managedDoc, pageNumbers) : null;
+            const generateAggregate = this.print_file != "signatures"
+            const generateSignatures = this.print_file != "aggregated"
+            const [pdf0PageNumbers, pdf1PageNumbers] = (!generateAggregate || this.duplex) ? [null, null]
+            : [
+                null,//this.rearrangedpages.reduce((accumulator, currentValue) => {return accumulator.concat(currentValue[0])},[]),
+                null//this.rearrangedpages.reduce((accumulator, currentValue) => {return accumulator.concat(currentValue[1])},[])
+              ]
+            const [aggregatePdf0, embeddedPages0] = (generateAggregate) ? await this.embedPagesInNewPdf(this.managedDoc, pdf0PageNumbers) : [null, null]
+            const [aggregatePdf1, embeddedPages1] = (generateAggregate && !this.duplex) ? await this.embedPagesInNewPdf(this.managedDoc, pdf1PageNumbers) : [null, null]
             const forLoop = async _ => {
                 for (let i = 0; i < this.rearrangedpages.length; i++) {
                     let page = this.rearrangedpages[i];
                     await this.createsignatures({
-                        embeddedPages: embeddedPages,
-                        aggregatePdf: aggregatePdf,
+                        embeddedPages: (generateAggregate) ? [embeddedPages0, embeddedPages1] : null,
+                        aggregatePdfs: (generateAggregate) ? [aggregatePdf0, aggregatePdf1] : null,
                         pageIndexes: page, 
-                        id: `signature${i}`,
+                        id: (generateSignatures) ? `signature${i}` : null,
                         isDuplex: this.duplex,
                         fileList: this.filelist
                     });
@@ -297,16 +313,22 @@ class Book {
             }
             await forLoop();
 
-            if (this.duplex && this.rearrangedpages.length > 1 && this.print_file != "signatures") {
-                await aggregatePdf.save().then(pdfBytes => { 
+            if (aggregatePdf1 != null) {
+                await aggregatePdf1.save().then(pdfBytes => { 
+                        if (!isPreview) 
+                            this.zip.file('aggregate_side2.pdf', pdfBytes); 
+                    });
+            }
+            if (aggregatePdf0 != null) {
+                await aggregatePdf0.save().then(pdfBytes => { 
                     if (!isPreview) 
-                        this.zip.file('aggregate_book.pdf', pdfBytes); 
+                        this.zip.file((this.duplex) ? 'aggregate_book.pdf' : 'aggregate_side1.pdf', pdfBytes); 
                 });
             }
             var rotationMetaInfo = ((this.paper_rotation_90) ? "_paperRotated" : "")
                 + ((this.source_rotation == 'none') ? "" : `_${this.source_rotation}`)
             this.filename = `${origFileName}${rotationMetaInfo}`
-            resultPDF = aggregatePdf;
+            resultPDF = aggregatePdf0;
         } else if (this.format == 'a9_3_3_4') {
             resultPDF = await this.buildSheets(this.filename, this.book.a9_3_3_4_builder());
         } else if (this.format == 'a10_6_10s') {
@@ -324,7 +346,7 @@ class Book {
         }
         console.log("Attempting to generate preview for ",resultPDF);
 
-        if (this.duplex && resultPDF != null) {
+        if (resultPDF != null) {
             const pdfDataUri = await resultPDF.saveAsBase64({ dataUri: true });
             const viewerPrefs = resultPDF.catalog.getOrCreateViewerPreferences()
             viewerPrefs.setHideToolbar(false)
@@ -339,8 +361,6 @@ class Book {
             previewFrame.style.height = `${height}px`;
             previewFrame.style.display = '';
             previewFrame.src = pdfDataUri;
-        } else if (isPreview) {
-            window.alert("I'm sorry, the preivew feature doesn't work with signature only settings yet")
         }
 
         if (!isPreview)
@@ -353,11 +373,28 @@ class Book {
      * @return the aggregate file w/ all the original pages embedded, but nothing placed
      */
     async create_base_aggregate_files() {
-        
         return aggregatePdf
     }
 
     /**
+     * Generates a new PDF & embeds the prescribed pages of the source PDF into it
+     * @param pageNumbers - an array of page numbers. Ex: [1,5,6,7,8] or null to embed all pages from source
+     *
+     * @return [newPdf with pages embedded, embedded page array]
+     */
+    async embedPagesInNewPdf(sourcePdf, pageNumbers) {
+        const newPdf = await pdf_lib__WEBPACK_IMPORTED_MODULE_0__.PDFDocument.create();
+        if (pageNumbers == null) {
+            pageNumbers = Array.from(Array(sourcePdf.getPageCount()).keys())
+        }
+        const embeddedPages =  await newPdf.embedPdf(sourcePdf, pageNumbers);
+        return [newPdf, embeddedPages]
+    }
+
+    /**
+     * Part of the Classic (non-Wacky) flow. Called by [createsignatures].
+     *   (conditionally) populates the destPdf and (conditionally) generates the outname PDF
+     *
      * @param config - object /w the following parameters:
      *      - outname : name of pdf added to ongoing zip file. Ex: 'signature1duplex.pdf' (or null if no signature file needed)
      *      - pageList : indicies of pages to assemble. Ex: [12, 11, 10, 13, 14, 9, 8, 15]
@@ -372,7 +409,6 @@ class Book {
         const printAggregate = config.providedPages != null && config.destPdf != null
         const pagelist = config.pageList;
         const back = config.back;
-        const outPDF = (printSignatures) ? await pdf_lib__WEBPACK_IMPORTED_MODULE_0__.PDFDocument.create() : null;
         let filteredList = [];
         let blankIndices = [];
         pagelist.forEach((page, i) => {
@@ -382,8 +418,8 @@ class Book {
                 blankIndices.push(i);
             }
         });
+        const [outPDF, embeddedPages] = (printSignatures) ? await this.embedPagesInNewPdf(this.managedDoc, filteredList) : [null, null];
 
-        let embeddedPages = (printSignatures) ? await outPDF.embedPdf(this.managedDoc, filteredList) : null;
         let destPdfPages = (printAggregate) ? filteredList.map( (pI) => {
             return config.providedPages[pI]
         }) : null
@@ -456,7 +492,7 @@ class Book {
         let currPage = outPDF.addPage([papersize[0], papersize[1]]);
 
         block.forEach((page, i) => {
-            if (page == 'b') {
+            if (page == 'b' || page === undefined) {
                 // blank page, move on.
             } else {
                 let pos = positions[i];
@@ -638,15 +674,7 @@ class Book {
             'bottom' : this.padding_pt['bottom'] * sy,
             'top' : this.padding_pt['top'] * sy
         };
-        // if (layout.landscape) {
-        //     padding = {
-        //         'fore_edge' : this.padding_pt['fore_edge'] * sx,
-        //         'binding' : this.padding_pt['binding'] * sx,
-        //         'bottom' : this.padding_pt['bottom'] * sy,
-        //         'top' : this.padding_pt['top'] * sy
-        //     };
-        // }
-       
+
         let positions = []
 
         console.log("Laying out page w/ scaling option [",this.page_scaling,"] & position option [",this.page_positioning,"] -"+
@@ -707,57 +735,60 @@ class Book {
     }
 
     /**
+     * PDF builder base function for Classic (non-Wacky) layouts. Called by [createoutputfiles]
+     *
      * @param config - object w/ the following parameters:
-     *    - pageIndexes : a nested list of original source document pages. Single list of list for duplex, two entries for non-duplex. Ex: [[4, 3, 2, 5, 6, 1, 0, 7]]
-     *    - aggregatePdfd : the destination PDFs for aggregated content ( [0] for duplex & front, [1] for backs -- value is null if no aggregate printing enabled)
-     *    - embeddedPages : all pages of source document, embedded in the aggregated PDFs (is null for non-duplex signature modes)
-     *    - id : string dentifier for signature/file info 
+     *    - pageIndexes : a nested list of original source document page numbers ordered for layout. ( [0] for duplex & front, [1] for backs -- value is null if no aggregate printing enabled). Ex: [[4, 3, 2, 5, 6, 1, 0, 7]]
+     *    - aggregatePdfs : list of destination PDF(s_ for aggregated content ( [0] for duplex & front, [1] for backs -- value is null if no aggregate printing enabled)
+     *    - embeddedPages : list of lists of embedded pages from source document ( [0] for duplex & front, [1] for backs -- value is null if no aggregate printing enabled)
+     *    - id : string dentifier for signature file name (null if no signature files to be generated)
      *    - isDuplex : boolean
      *    - fileList : list of filenames for sig filename to be added to (modifies list)
      */
     async createsignatures(config) {
-        const printAggregate = this.print_file != "signatures"
-        const printSignatures = this.print_file != "aggregated"
+        const printAggregate = config.aggregatePdfs != null
+        const printSignatures = config.id != null
         const pages = config.pageIndexes;
-        const id = config.id;
-        console.log("Rebecca: createsignatures : pages : ", pages)
         //      duplex printers print both sides of the sheet, 
         if (config.isDuplex) {
-            // let outduplex = this.outputpath + '/' + id + 'duplex' + '.pdf';
-            let outduplex = id + 'duplex' + '.pdf';
+            let outduplex = (printSignatures) ? config.id + 'duplex' + '.pdf' : null;
             await this.writepages({
-                outname: (printSignatures) ? outduplex : null, 
+                outname: outduplex, 
                 pageList: pages[0], 
                 back: false, 
                 alt: true,
-                destPdf: (printAggregate) ? config.aggregatePdf : null,
-                providedPages: (printAggregate) ? config.embeddedPages : null
+                destPdf: (printAggregate) ? config.aggregatePdfs[0] : null,
+                providedPages: (printAggregate) ? config.embeddedPages[0] : null
             });
             if (printSignatures) {
                 config.fileList.push(outduplex);
             }
         } else {
             //      for non-duplex printers we have two files, print the first, flip 
-            //      the sheets over, then print the second. damned inconvenient
-            let outname1 = id + 'side1.pdf';
-            let outname2 = id + 'side2.pdf';
-            const aggregatedBacks = config.aggregatePdf
+            //      the sheets over, then print the second
+            let outname1 = (printSignatures) ? config.id + 'side1.pdf' : null;
+            let outname2 = (printSignatures) ? config.id + 'side2.pdf' : null;
  
             await this.writepages({
-                outname: outname1, 
-                pageList: pages[0], 
-                back: false, 
-                alt: false
+                outname: outname1,
+                pageList: pages[0],
+                back: false,
+                alt: false,
+                destPdf: (printAggregate) ? config.aggregatePdfs[0] : null,
+                providedPages: (printAggregate) ? config.embeddedPages[0] : null
             });
             await this.writepages({
-                outname: outname2, 
-                pageList: pages[1], 
-                back: true, 
-                alt: false
+                outname: outname2,
+                pageList: pages[1],
+                back: true,
+                alt: false,
+                destPdf: (printAggregate) ? config.aggregatePdfs[1] : null,
+                providedPages: (printAggregate) ? config.embeddedPages[1] : null
             });
-
-            config.fileList.push(outname1);
-            config.fileList.push(outname2);
+            if (printSignatures) {
+                config.fileList.push(outname1);
+                config.fileList.push(outname2);
+            }
         }
         console.log("After creating signatures, our filelist looks like: ",this.filelist)
     }
@@ -774,7 +805,11 @@ class Book {
     /**
      * @param id - base for the final PDF name
      * @param builder - object to help construct this configuration. Object definition: {
-     *      sheetMaker: function that takes the page count as a param and returns an array of sheets,
+     *      sheetMaker: function that takes the page count as a param and returns an array of sheets. A sheet is { 
+     *            num: page number from original doc, 
+     *            isBlank: true renders it blank-- will override any `num` included,
+     *            vFlip: true if rendered upside down (180 rotation)
+     *       },
      *      lineMaker: function that makes a function that generates trim lines for the PDF,
      *      isLandscape: true if we need to have largest dimension be width,
      *      fileNameMod: string to affix to exported file name (contains no buffer begin/end characters)
@@ -785,6 +820,7 @@ class Book {
         let sheets = builder.sheetMaker(this.pagecount);
         let lineMaker = builder.lineMaker();
         console.log("Working with the sheet descritpion: ", sheets);
+        // embedPagesInNewPdf
         const outPDF = await pdf_lib__WEBPACK_IMPORTED_MODULE_0__.PDFDocument.create();
         const outPDF_back = await pdf_lib__WEBPACK_IMPORTED_MODULE_0__.PDFDocument.create();
 

--- a/preload.js
+++ b/preload.js
@@ -258,7 +258,7 @@ class Book {
     }
 
     /**
-     * Calls the appropriate builder basec on [this.format]
+     * Calls the appropriate builder based on [this.format]
      *  to generate PDF & populate Previewer
      * @param isPreview - if it's true we only generate preview content, if it's not true... we still 
      *      generate preview content AND a downloadable zip

--- a/preload.js
+++ b/preload.js
@@ -379,7 +379,9 @@ class Book {
 
     /**
      * Generates a new PDF & embeds the prescribed pages of the source PDF into it
+     *
      * @param pageNumbers - an array of page numbers. Ex: [1,5,6,7,8,'b',10] or null to embed all pages from source
+     *          NOTE: re-construction behavior kicks in if there's 'b's in the list
      *
      * @return [newPdf with pages embedded, embedded page array]
      */
@@ -392,14 +394,16 @@ class Book {
             pageNumbers = pageNumbers.filter( p => {return typeof p === 'number'})
         }
         let embeddedPages =  await newPdf.embedPdf(sourcePdf, pageNumbers);
+        // what a gnarly little hack. Letting this sit for now -- 
+        //   --- downstream code requires embeds to be in their 'correct' index possition
+        //    but we want to only embed half the pages for the aggregate single sides
+        //    thus we expand the embedded pages to allow those gaps to return. This is gross & dumb but whatever...
         if (needsReSorting) {
             embeddedPages = embeddedPages.reduce((acc, curVal, curI) => {
-                console.log("Weeeee....",acc)
                 acc[pageNumbers[curI]] = curVal;
                 return acc
             },[])
         }
-        console.log("Rebecca, we got a new embedded pages [",needsReSorting," : ",pageNumbers,"] : ", embeddedPages)
         return [newPdf, embeddedPages]
     }
 

--- a/src/book.js
+++ b/src/book.js
@@ -269,11 +269,12 @@ export class Book {
         } else if (this.format == 'standardsig' || this.format == 'customsig') {
             const generateAggregate = this.print_file != "signatures"
             const generateSignatures = this.print_file != "aggregated"
+            const side1PageNumbers = new Set(this.rearrangedpages.reduce((accumulator, currentValue) => { return accumulator.concat(currentValue[0]) },[]))
             const [pdf0PageNumbers, pdf1PageNumbers] = (!generateAggregate || this.duplex) ? [null, null]
-            : {return [
-                null,//this.rearrangedpages.reduce((accumulator, currentValue) => {return accumulator.concat(currentValue[0])},[]),
-                null//this.rearrangedpages.reduce((accumulator, currentValue) => {return accumulator.concat(currentValue[1])},[])
-              ]}()
+            : [
+                Array.from(Array(this.managedDoc.getPageCount()).keys()).map( p => { return (side1PageNumbers.has(p) ? p : 'b')}),
+                Array.from(Array(this.managedDoc.getPageCount()).keys()).map( p => { return (!side1PageNumbers.has(p) ? p : 'b')})
+              ];
             const [aggregatePdf0, embeddedPages0] = (generateAggregate) ? await this.embedPagesInNewPdf(this.managedDoc, pdf0PageNumbers) : [null, null]
             const [aggregatePdf1, embeddedPages1] = (generateAggregate && !this.duplex) ? await this.embedPagesInNewPdf(this.managedDoc, pdf1PageNumbers) : [null, null]
             const forLoop = async _ => {
@@ -356,16 +357,31 @@ export class Book {
 
     /**
      * Generates a new PDF & embeds the prescribed pages of the source PDF into it
-     * @param pageNumbers - an array of page numbers. Ex: [1,5,6,7,8] or null to embed all pages from source
+     *
+     * @param pageNumbers - an array of page numbers. Ex: [1,5,6,7,8,'b',10] or null to embed all pages from source
+     *          NOTE: re-construction behavior kicks in if there's 'b's in the list
      *
      * @return [newPdf with pages embedded, embedded page array]
      */
     async embedPagesInNewPdf(sourcePdf, pageNumbers) {
         const newPdf = await PDFDocument.create();
+        const needsReSorting = pageNumbers != null && pageNumbers.includes("b");
         if (pageNumbers == null) {
             pageNumbers = Array.from(Array(sourcePdf.getPageCount()).keys())
+        } else {
+            pageNumbers = pageNumbers.filter( p => {return typeof p === 'number'})
         }
-        const embeddedPages =  await newPdf.embedPdf(sourcePdf, pageNumbers);
+        let embeddedPages =  await newPdf.embedPdf(sourcePdf, pageNumbers);
+        // what a gnarly little hack. Letting this sit for now -- 
+        //   --- downstream code requires embeds to be in their 'correct' index possition
+        //    but we want to only embed half the pages for the aggregate single sides
+        //    thus we expand the embedded pages to allow those gaps to return. This is gross & dumb but whatever...
+        if (needsReSorting) {
+            embeddedPages = embeddedPages.reduce((acc, curVal, curI) => {
+                acc[pageNumbers[curI]] = curVal;
+                return acc
+            },[])
+        }
         return [newPdf, embeddedPages]
     }
 
@@ -798,7 +814,6 @@ export class Book {
         let sheets = builder.sheetMaker(this.pagecount);
         let lineMaker = builder.lineMaker();
         console.log("Working with the sheet descritpion: ", sheets);
-        // embedPagesInNewPdf
         const outPDF = await PDFDocument.create();
         const outPDF_back = await PDFDocument.create();
 

--- a/src/book.js
+++ b/src/book.js
@@ -270,10 +270,10 @@ export class Book {
             const generateAggregate = this.print_file != "signatures"
             const generateSignatures = this.print_file != "aggregated"
             const [pdf0PageNumbers, pdf1PageNumbers] = (!generateAggregate || this.duplex) ? [null, null]
-            : [
+            : {return [
                 null,//this.rearrangedpages.reduce((accumulator, currentValue) => {return accumulator.concat(currentValue[0])},[]),
                 null//this.rearrangedpages.reduce((accumulator, currentValue) => {return accumulator.concat(currentValue[1])},[])
-              ]
+              ]}()
             const [aggregatePdf0, embeddedPages0] = (generateAggregate) ? await this.embedPagesInNewPdf(this.managedDoc, pdf0PageNumbers) : [null, null]
             const [aggregatePdf1, embeddedPages1] = (generateAggregate && !this.duplex) ? await this.embedPagesInNewPdf(this.managedDoc, pdf1PageNumbers) : [null, null]
             const forLoop = async _ => {

--- a/src/book.js
+++ b/src/book.js
@@ -236,7 +236,7 @@ export class Book {
     }
 
     /**
-     * Calls the appropriate builder basec on [this.format]
+     * Calls the appropriate builder based on [this.format]
      *  to generate PDF & populate Previewer
      * @param isPreview - if it's true we only generate preview content, if it's not true... we still 
      *      generate preview content AND a downloadable zip

--- a/src/book.js
+++ b/src/book.js
@@ -17,6 +17,7 @@ export class Book {
         this.papersize = PAGE_SIZES.A4;   //  default for europe
         this.paper_rotation_90 = false; // make the printed page landscape [for landscaped layouts, results in portait]
 
+        this.print_file = 'both';   //valid options: [aggregated, both, signatures]
         // valid rotation options: [none, 90cw, 90ccw, out_binding, in_binding]
         this.source_rotation = 'none'; // new feature to rotate pages on the sheets 2023/3/09
         this.managedDoc = null; // original PDF with the pages rotated per source_rotation - use THIS for laying out pages
@@ -61,6 +62,7 @@ export class Book {
 
         this.source_rotation = form.get("source_rotation");
         
+        this.print_file = form.get("print_file");
         this.page_scaling = form.get("page_scaling");
         this.page_positioning = form.get("page_positioning");
         this.flyleaf = form.has('flyleaf');
@@ -255,9 +257,9 @@ export class Book {
                 fileList: this.filelist
             });
         } else if (this.format == 'standardsig' || this.format == 'customsig') {
-            const aggregatePdf = await PDFDocument.create();
+            const aggregatePdf = (this.print_file != "signatures") ? await PDFDocument.create() : null;
             var pageNumbers = Array.from(Array(this.managedDoc.getPageCount()).keys())
-            let embeddedPages = await aggregatePdf.embedPdf(this.managedDoc, pageNumbers);
+            let embeddedPages = (this.print_file != "signatures") ? await aggregatePdf.embedPdf(this.managedDoc, pageNumbers) : null;
             const forLoop = async _ => {
                 for (let i = 0; i < this.rearrangedpages.length; i++) {
                     let page = this.rearrangedpages[i];
@@ -273,9 +275,8 @@ export class Book {
             }
             await forLoop();
 
-            if (this.duplex && this.rearrangedpages.length > 1) {
+            if (this.duplex && this.rearrangedpages.length > 1 && this.print_file != "signatures") {
                 await aggregatePdf.save().then(pdfBytes => { 
-                // await this.managedDoc.save().then(pdfBytes => { 
                     if (!isPreview) 
                         this.zip.file('aggregate_book.pdf', pdfBytes); 
                 });
@@ -301,7 +302,7 @@ export class Book {
         }
         console.log("Attempting to generate preview for ",resultPDF);
 
-        if (this.duplex) {
+        if (this.duplex && resultPDF != null) {
             const pdfDataUri = await resultPDF.saveAsBase64({ dataUri: true });
             const viewerPrefs = resultPDF.catalog.getOrCreateViewerPreferences()
             viewerPrefs.setHideToolbar(false)
@@ -317,7 +318,7 @@ export class Book {
             previewFrame.style.display = '';
             previewFrame.src = pdfDataUri;
         } else if (isPreview) {
-            window.alert("I'm sorry, the preivew feature doesn't work with non-duplex settings yet")
+            window.alert("I'm sorry, the preivew feature doesn't work with signature only settings yet")
         }
 
         if (!isPreview)
@@ -327,8 +328,16 @@ export class Book {
     }
 
     /**
+     * @return the aggregate file w/ all the original pages embedded, but nothing placed
+     */
+    async create_base_aggregate_files() {
+        
+        return aggregatePdf
+    }
+
+    /**
      * @param config - object /w the following parameters:
-     *      - outname : name of pdf added to ongoing zip file. Ex: 'signature1duplex.pdf'
+     *      - outname : name of pdf added to ongoing zip file. Ex: 'signature1duplex.pdf' (or null if no signature file needed)
      *      - pageList : indicies of pages to assemble. Ex: [12, 11, 10, 13, 14, 9, 8, 15]
      *      - back : is 'back' of page  (boolean)
      *      - alt : alternate pages (boolean)
@@ -337,11 +346,11 @@ export class Book {
      * @return reference to the new PDF created
      */
     async writepages(config) {
-        const outname = config.outname;
+        const printSignatures = config.outname != null
+        const printAggregate = config.providedPages != null && config.destPdf != null
         const pagelist = config.pageList;
         const back = config.back;
-        const alt = config.alt;
-        const outPDF = await PDFDocument.create();
+        const outPDF = (printSignatures) ? await PDFDocument.create() : null;
         let filteredList = [];
         let blankIndices = [];
         pagelist.forEach((page, i) => {
@@ -352,13 +361,15 @@ export class Book {
             }
         });
 
-        let embeddedPages = await outPDF.embedPdf(this.managedDoc, filteredList);
-        let destPdfPages = (config.providedPages == null) ? null : filteredList.map( (pI) => {
+        let embeddedPages = (printSignatures) ? await outPDF.embedPdf(this.managedDoc, filteredList) : null;
+        let destPdfPages = (printAggregate) ? filteredList.map( (pI) => {
             return config.providedPages[pI]
-        })
+        }) : null
 
-        blankIndices.forEach(i => embeddedPages.splice(i, 0, 'b'));
-        blankIndices.forEach(i => destPdfPages.splice(i, 0, 'b'));
+        if (printSignatures)
+            blankIndices.forEach(i => embeddedPages.splice(i, 0, 'b'));
+        if (printAggregate)
+            blankIndices.forEach(i => destPdfPages.splice(i, 0, 'b'));
 
         let block_start = 0;
         const offset = this.per_sheet / 2;
@@ -371,7 +382,7 @@ export class Book {
         let side2flag = back;
     
         while (block_end <= pagelist.length) {
-            if (config.destPdf) {
+            if (printAggregate) {
                 this.draw_block_onto_page({
                     outPDF: config.destPdf,
                     embeddedPages: destPdfPages,
@@ -381,27 +392,31 @@ export class Book {
                     positions: positions,
                     cropmarks: this.cropmarks,
                     cutmarks: this.cutmarks,
-                    alt: alt,
+                    alt: config.alt,
                     side2flag: side2flag
                 });
             }
-            side2flag = this.draw_block_onto_page({
-                outPDF: outPDF,
-                embeddedPages: embeddedPages,
-                block_start: block_start,
-                block_end: block_end,
-                papersize: this.papersize,
-                positions: positions,
-                cropmarks: this.cropmarks,
-                cutmarks: this.cutmarks,
-                alt: alt,
-                side2flag: side2flag
-            });
+            if (printSignatures) {
+                side2flag = this.draw_block_onto_page({
+                    outPDF: outPDF,
+                    embeddedPages: embeddedPages,
+                    block_start: block_start,
+                    block_end: block_end,
+                    papersize: this.papersize,
+                    positions: positions,
+                    cropmarks: this.cropmarks,
+                    cutmarks: this.cutmarks,
+                    alt: config.alt,
+                    side2flag: side2flag
+                });
+            }
             block_start += offset;
             block_end += offset;
         }
 
-        await outPDF.save().then(pdfBytes => { this.zip.file(outname, pdfBytes); });
+        if (printSignatures) {
+            await outPDF.save().then(pdfBytes => { this.zip.file(config.outname, pdfBytes); });
+        }
     }
 
     draw_block_onto_page(config) {
@@ -672,13 +687,15 @@ export class Book {
     /**
      * @param config - object w/ the following parameters:
      *    - pageIndexes : a nested list of original source document pages. Single list of list for duplex, two entries for non-duplex. Ex: [[4, 3, 2, 5, 6, 1, 0, 7]]
-     *    - aggregatePdf : the destination PDF for aggregated content in duplex signature mode (is null otherwise)
-     *    - embeddedPages : all pages of source document, embedded in the aggregated PDF (is null for non-duplex signature modes)
+     *    - aggregatePdfd : the destination PDFs for aggregated content ( [0] for duplex & front, [1] for backs -- value is null if no aggregate printing enabled)
+     *    - embeddedPages : all pages of source document, embedded in the aggregated PDFs (is null for non-duplex signature modes)
      *    - id : string dentifier for signature/file info 
      *    - isDuplex : boolean
      *    - fileList : list of filenames for sig filename to be added to (modifies list)
      */
     async createsignatures(config) {
+        const printAggregate = this.print_file != "signatures"
+        const printSignatures = this.print_file != "aggregated"
         const pages = config.pageIndexes;
         const id = config.id;
         console.log("Rebecca: createsignatures : pages : ", pages)
@@ -687,19 +704,22 @@ export class Book {
             // let outduplex = this.outputpath + '/' + id + 'duplex' + '.pdf';
             let outduplex = id + 'duplex' + '.pdf';
             await this.writepages({
-                outname: outduplex, 
+                outname: (printSignatures) ? outduplex : null, 
                 pageList: pages[0], 
                 back: false, 
                 alt: true,
-                destPdf: config.aggregatePdf,
-                providedPages: config.embeddedPages
+                destPdf: (printAggregate) ? config.aggregatePdf : null,
+                providedPages: (printAggregate) ? config.embeddedPages : null
             });
-            config.fileList.push(outduplex);
+            if (printSignatures) {
+                config.fileList.push(outduplex);
+            }
         } else {
             //      for non-duplex printers we have two files, print the first, flip 
             //      the sheets over, then print the second. damned inconvenient
             let outname1 = id + 'side1.pdf';
             let outname2 = id + 'side2.pdf';
+            const aggregatedBacks = config.aggregatePdf
  
             await this.writepages({
                 outname: outname1, 

--- a/src/book.js
+++ b/src/book.js
@@ -218,7 +218,6 @@ export class Book {
             } else {
                 this.book.createsigconfig();
             }
-
             this.rearrangedpages = this.book.pagelist;
         } else if (this.format == 'a9_3_3_4' || this.format == 'a10_6_10s' || this.format == 'A7_2_16s' || this.format == '1_3rd' || this.format == '8_zine'|| this.format == 'a_3_6s' || this.format == 'a_4_8s') {
             this.book = new WackyImposition(this.orderedpages, this.duplex, this.format, this.pack_pages)
@@ -242,19 +241,34 @@ export class Book {
         this.filename = origFileName
 
         if (this.format == 'booklet') {
-            await this.createsignatures(this.rearrangedpages, 'booklet');
+            await this.createsignatures({
+                pages: this.rearrangedpages, 
+                id: 'booklet',
+                isDuplex: this.duplex,
+                fileList: this.fileList
+            });
         } else if (this.format == 'perfect') {
-            await this.createsignatures(this.rearrangedpages, 'perfect');
+            await this.createsignatures({
+                pages: this.rearrangedpages, 
+                id: 'perfect',
+                isDuplex: this.duplex,
+                fileList: this.filelist
+            });
         } else if (this.format == 'standardsig' || this.format == 'customsig') {
             const aggregatePdf = await PDFDocument.create();
+            var pageNumbers = Array.from(Array(this.managedDoc.getPageCount()).keys())
+            let embeddedPages = await aggregatePdf.embedPdf(this.managedDoc, pageNumbers);
             const forLoop = async _ => {
                 for (let i = 0; i < this.rearrangedpages.length; i++) {
                     let page = this.rearrangedpages[i];
-                    const newPDF = await this.createsignatures(page, `signature${i}`);
-                    if (newPDF != null) {
-                        const dupPages = await aggregatePdf.copyPages(newPDF, newPDF.getPageIndices());
-                        dupPages.forEach( page => { aggregatePdf.addPage(page); });
-                    }
+                    await this.createsignatures({
+                        embeddedPages: embeddedPages,
+                        aggregatePdf: aggregatePdf,
+                        pageIndexes: page, 
+                        id: `signature${i}`,
+                        isDuplex: this.duplex,
+                        fileList: this.filelist
+                    });
                 }
             }
             await forLoop();
@@ -313,11 +327,21 @@ export class Book {
     }
 
     /**
+     * @param config - object /w the following parameters:
+     *      - outname : name of pdf added to ongoing zip file. Ex: 'signature1duplex.pdf'
+     *      - pageList : indicies of pages to assemble. Ex: [12, 11, 10, 13, 14, 9, 8, 15]
+     *      - back : is 'back' of page  (boolean)
+     *      - alt : alternate pages (boolean)
+     *      - destPdf : PDF to write to, in addition to PDF created w/ `outname` (or null)
+     *      - providedPages : pages already embedded in the `destPdf` to assemble in addition (or null)
      * @return reference to the new PDF created
      */
-    async writepages(outname, pagelist, back, alt) {
+    async writepages(config) {
+        const outname = config.outname;
+        const pagelist = config.pageList;
+        const back = config.back;
+        const alt = config.alt;
         const outPDF = await PDFDocument.create();
-        let currPage = null;
         let filteredList = [];
         let blankIndices = [];
         pagelist.forEach((page, i) => {
@@ -329,7 +353,12 @@ export class Book {
         });
 
         let embeddedPages = await outPDF.embedPdf(this.managedDoc, filteredList);
+        let destPdfPages = (config.providedPages == null) ? null : filteredList.map( (pI) => {
+            return config.providedPages[pI]
+        })
+
         blankIndices.forEach(i => embeddedPages.splice(i, 0, 'b'));
+        blankIndices.forEach(i => destPdfPages.splice(i, 0, 'b'));
 
         let block_start = 0;
         const offset = this.per_sheet / 2;
@@ -342,40 +371,72 @@ export class Book {
         let side2flag = back;
     
         while (block_end <= pagelist.length) {
-            
-            let block = embeddedPages.slice(block_start, block_end);
-            currPage = outPDF.addPage([this.papersize[0], this.papersize[1]]);
-
-            block.forEach((page, i) => {
-                if (page == 'b') {
-                    // blank page, move on.
-                } else {
-                    let pos = positions[i];
-                    let rot = pos.rotation;
-
-                    currPage.drawPage(page, { y: pos.y, x: pos.x, xScale: pos.sx, yScale: pos.sy, rotate: degrees(rot) });
-                }
-    
-            })
-
-            if (this.cropmarks) {
-                this.draw_cropmarks(currPage, side2flag);
+            if (config.destPdf) {
+                this.draw_block_onto_page({
+                    outPDF: config.destPdf,
+                    embeddedPages: destPdfPages,
+                    block_start: block_start,
+                    block_end: block_end,
+                    papersize: this.papersize,
+                    positions: positions,
+                    cropmarks: this.cropmarks,
+                    cutmarks: this.cutmarks,
+                    alt: alt,
+                    side2flag: side2flag
+                });
             }
-
-            if (this.cutmarks) {
-                this.draw_cutmarks(currPage)
-            }
-
-            if (alt) {
-                side2flag = !side2flag;
-            }
-
+            side2flag = this.draw_block_onto_page({
+                outPDF: outPDF,
+                embeddedPages: embeddedPages,
+                block_start: block_start,
+                block_end: block_end,
+                papersize: this.papersize,
+                positions: positions,
+                cropmarks: this.cropmarks,
+                cutmarks: this.cutmarks,
+                alt: alt,
+                side2flag: side2flag
+            });
             block_start += offset;
             block_end += offset;
         }
 
         await outPDF.save().then(pdfBytes => { this.zip.file(outname, pdfBytes); });
-        return outPDF;
+    }
+
+    draw_block_onto_page(config) {
+        const block_start = config.block_start
+        const block_end = config.block_end
+        const papersize = config.papersize
+        const outPDF = config.outPDF
+        const positions = config.positions
+        const cropmarks = config.cropmarks
+        const cutmarks = config.cutmarks
+        const alt = config.alt
+        let side2flag = config.side2flag
+
+        let block = config.embeddedPages.slice(block_start, block_end);
+        let currPage = outPDF.addPage([papersize[0], papersize[1]]);
+
+        block.forEach((page, i) => {
+            if (page == 'b') {
+                // blank page, move on.
+            } else {
+                let pos = positions[i];
+                let rot = pos.rotation;
+                currPage.drawPage(page, { y: pos.y, x: pos.x, xScale: pos.sx, yScale: pos.sy, rotate: degrees(rot) });
+            }
+        });
+        if (cropmarks) {
+            this.draw_cropmarks(currPage, side2flag);
+        }
+        if (cutmarks) {
+            this.draw_cutmarks(currPage)
+        }
+        if (alt) {
+            side2flag = !side2flag;
+        }
+        return side2flag
     }
 
     draw_cropmarks(currPage, side2flag) {
@@ -609,32 +670,54 @@ export class Book {
     }
 
     /**
-     * @param pages - a nested list of original source document pages. Single list of list for duplex, two entries for non-duplex
-     *
-     * @return returns a newly created PDF if duplex or null
+     * @param config - object w/ the following parameters:
+     *    - pageIndexes : a nested list of original source document pages. Single list of list for duplex, two entries for non-duplex. Ex: [[4, 3, 2, 5, 6, 1, 0, 7]]
+     *    - aggregatePdf : the destination PDF for aggregated content in duplex signature mode (is null otherwise)
+     *    - embeddedPages : all pages of source document, embedded in the aggregated PDF (is null for non-duplex signature modes)
+     *    - id : string dentifier for signature/file info 
+     *    - isDuplex : boolean
+     *    - fileList : list of filenames for sig filename to be added to (modifies list)
      */
-    async createsignatures(pages, id) {
-        let result = null;
+    async createsignatures(config) {
+        const pages = config.pageIndexes;
+        const id = config.id;
+        console.log("Rebecca: createsignatures : pages : ", pages)
         //      duplex printers print both sides of the sheet, 
-        if (this.duplex) {
+        if (config.isDuplex) {
             // let outduplex = this.outputpath + '/' + id + 'duplex' + '.pdf';
             let outduplex = id + 'duplex' + '.pdf';
-            result = await this.writepages(outduplex, pages[0], false, true);
-            this.filelist.push(outduplex);
+            await this.writepages({
+                outname: outduplex, 
+                pageList: pages[0], 
+                back: false, 
+                alt: true,
+                destPdf: config.aggregatePdf,
+                providedPages: config.embeddedPages
+            });
+            config.fileList.push(outduplex);
         } else {
             //      for non-duplex printers we have two files, print the first, flip 
             //      the sheets over, then print the second. damned inconvenient
             let outname1 = id + 'side1.pdf';
             let outname2 = id + 'side2.pdf';
  
-            await this.writepages(outname1, pages[0], false, false);
-            await this.writepages(outname2, pages[1], true, false);
+            await this.writepages({
+                outname: outname1, 
+                pageList: pages[0], 
+                back: false, 
+                alt: false
+            });
+            await this.writepages({
+                outname: outname2, 
+                pageList: pages[1], 
+                back: true, 
+                alt: false
+            });
 
-            this.filelist.push(outname1);
-            this.filelist.push(outname2);
+            config.fileList.push(outname1);
+            config.fileList.push(outname2);
         }
         console.log("After creating signatures, our filelist looks like: ",this.filelist)
-        return result;
     }
 
     saveZip() {


### PR DESCRIPTION
[THIS LINK HERE](https://htmlpreview.github.io/?https://github.com/momijizukamori/bookbinder-js/blob/six_full_size_fix/index.html) should let you test the PR out

Key changes:
- Added **Downloaded File(s)** to the Page Layout section (since it doesn't impact the wackies) - can now download just aggregate, just signatures, or both
<img width="528" alt="page_layout" src="https://github.com/momijizukamori/bookbinder-js/assets/1319240/583bbef5-d398-4546-8217-b980f8abef56">

- Also-- added a **current version number** to the top of the page because I want to be more clear going forward about when things change/what version people are using

<img width="514" alt="version_info" src="https://github.com/momijizukamori/bookbinder-js/assets/1319240/65f21ffe-1ae7-4af4-ad1f-423c6f9665f6">

- Preview now works with Single sided (only shows one side & only if the aggregate files are enabled) 


Code wides:
- Added comments (JavaDoc style) for some functions
- refactored some code to take config objects rather than a list of parameters & references to member variables
- there's a little tangle of stupid around the embedding of pages in `createoutputfiles` (splitting the even/odds to reduce file size-- no point in embedding pages you wont use!) that makes for not-so-obvious choices in `embedPagesInNewPdf` ... but I'm done fighting it at the moment and just want the fix in place


