### PR TITLE
Re-doing PDF positioning logic & adding preview to PDF in Cell placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,18 @@
                     Binding Margin: <input type="number" id="binding_edge_padding_pt" name="binding_edge_padding_pt" style="width: 5em;margin-left: 15px;"> pt<BR>
                     Top Margin: <input type="number" id="top_edge_padding_pt" name="top_edge_padding_pt" style="width: 5em;margin-left: 15px;"> pt<BR>
                     Bottom Margin: <input type="number" id="bottom_edge_padding_pt" name="bottom_edge_padding_pt" style="width: 5em;margin-left: 15px;"> pt<BR>
+
+                    <div class="show_layout_info">
+                        <div id="layout_margin_info">sharks and candy</div>
+
+                        <div class="grid_layout_page" id="grid_layout_preview">
+                            <div class="pdf_layout_page" id="pdf_on_page_layout_preview"></div>
+                        </div>
+                        <div class="overall_page" id="overall_page_layout_preview">
+                            <div class="grid_layout" id="overall_grid_preview"></div>
+                        </div>
+                        <div id="layout_offset_info">bob joe sam</div>
+                    </div>
                 </span>
 
                 <span class="row"><label for="print_file">Downloaded File(s)</label>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
             contribute, view the project's <a href="https://github.com/momijizukamori/bookbinder-js">Github repository</a>.
             If you have issues with this version, you can try the <a href="old/">old version</a> instead, which only supports folio layouts.
             <center style="font-family:monospace;
-    padding-top: 0.75em;font-variant-caps: small-caps;">current version: 1.0.0</center>
+    padding-top: 0.75em;font-variant-caps: small-caps;">current version: 1.1.0</center>
         </div>
         <form id="bookbinder" name="bookbinder">
             <div class="section" id="input">
@@ -185,7 +185,7 @@
                         source: <span id="pdf_source_dimensions"></span><BR>
                         on page: <span id="pdf_page_dimensions"></span><BR>
                         scaling: <span id="pdf_scale_dimensions"></span><BR>
-                        offset: <span id="pdf_offset_dimensions"></span><BR>
+                        offset: <div style="display:inline;"><div id="pdf_offset_dimensions" style="padding-left: 10px;display: inline-block;vertical-align: top;"></div></div><BR>
                         rotated: <span id="pdf_page_rotation_info"></span><BR>
                         
                         Debug: <span id="layout_debug_info"></span>

--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
 
                 <span class="row">
                     <div style="width:225px;position: absolute;margin-left: 250px;font-size: smaller;">
-                        White Space Manipulation. All values are in points, relative to original document. Use negative margins to reposition without scalig. <BR>1 point = 1/72 inch
+                        White Space Manipulation. All values are in points, relative to original document.<BR><BR>1 point = 1/72 inch
                     </div>
                     <div style="width:225px;margin-top:15px;margin-bottom:15px;text-align: right;">
                         Fore-Edge Margin: <input type="number" id="main_fore_edge_padding_pt" name="main_fore_edge_padding_pt" style="width: 4em;margin-left: 10px;"><sub>pt</sub></BR>
@@ -187,8 +187,6 @@
                         scaling: <span id="pdf_scale_dimensions"></span><BR>
                         offset: <div style="display:inline;"><div id="pdf_offset_dimensions" style="padding-left: 10px;display: inline-block;vertical-align: top;"></div></div><BR>
                         rotated: <span id="pdf_page_rotation_info"></span><BR>
-                        
-                        Debug: <span id="layout_debug_info"></span>
                         <BR>
                         (<i>all dimensions are in Points</i>)
 

--- a/index.html
+++ b/index.html
@@ -160,31 +160,42 @@
                     </select>
                 </span>
 
-                <span class="row"> <label for="center_margins">Margins</label>
-                    <select name="center_margins" id="center_margins" disabled>
-                        <option value="spine" selected>Preserve spine fold margin</option>
-                        <option value="center">Center</option>
-                    </select>
-                    <span data-balloon-length="medium" aria-label="If you have designed your input pdf with the intention of trimming printed pages down, you may wish to preserve the spine margin." data-balloon-pos="up">ℹ️</span>
+                <span class="row">
+                    <div style="width:225px;position: absolute;margin-left: 250px;font-size: smaller;">
+                        White Space Manipulation. All values are in points, relative to original document. Use negative margins to reposition without scalig. <BR>1 point = 1/72 inch
+                    </div>
+                    <div style="width:225px;margin-top:15px;margin-bottom:15px;text-align: right;">
+                        Fore-Edge Margin: <input type="number" id="main_fore_edge_padding_pt" name="main_fore_edge_padding_pt" style="width: 4em;margin-left: 10px;"><sub>pt</sub></BR>
+                        Binding Margin: <input type="number" id="binding_edge_padding_pt" name="binding_edge_padding_pt" style="width: 4em;margin-left: 10px;"><sub>pt</sub></BR>
+                        Top Margin: <input type="number" id="top_edge_padding_pt" name="top_edge_padding_pt" style="width: 4em;margin-left: 10px;"><sub>pt</sub></BR>
+                        Bottom Margin: <input type="number" id="bottom_edge_padding_pt" name="bottom_edge_padding_pt" style="width: 4em;margin-left: 10px;"><sub>pt</sub></BR>
+                    </div>
                 </span>
 
-                <span class="row">
-                    White Space Manipulation. All values are in points, relative to original document. 1 point = 1/72 inch<BR>
-                    Fore-Edge Margin: <input type="number" id="main_fore_edge_padding_pt" name="main_fore_edge_padding_pt" style="width: 5em;margin-left: 15px;"> pt<BR>
-                    Binding Margin: <input type="number" id="binding_edge_padding_pt" name="binding_edge_padding_pt" style="width: 5em;margin-left: 15px;"> pt<BR>
-                    Top Margin: <input type="number" id="top_edge_padding_pt" name="top_edge_padding_pt" style="width: 5em;margin-left: 15px;"> pt<BR>
-                    Bottom Margin: <input type="number" id="bottom_edge_padding_pt" name="bottom_edge_padding_pt" style="width: 5em;margin-left: 15px;"> pt<BR>
+                <span class="row" id="show_layout_info">
+                    <div class="layout_spine_label">spine</div>
+                    <div class="layout_margin_info" id="layout_margin_info">
+                        <div class="stripes_paper" style="width:20px;height:20px;display:inline-block;"></div> 
+                        <b>Paper/Layout Dimensions</b>
+                        layout: <span id="page_grid_layout"></span><BR>
+                        max page size: <span id="page_grid_dimensions"></span><BR>
+                        <br>
+                        <div class="stripes_pdf" style="width:20px;height:20px;display:inline-block;"></div> 
+                        <b>PDF Dimensions</b><BR>
+                        source: <span id="pdf_source_dimensions"></span><BR>
+                        on page: <span id="pdf_page_dimensions"></span><BR>
+                        scaling: <span id="pdf_scale_dimensions"></span><BR>
+                        offset: <span id="pdf_offset_dimensions"></span><BR>
+                        rotated: <span id="pdf_page_rotation_info"></span><BR>
+                        
+                        Debug: <span id="layout_debug_info"></span>
+                        <BR>
+                        (<i>all dimensions are in Points</i>)
 
-                    <div class="show_layout_info">
-                        <div id="layout_margin_info">sharks and candy</div>
+                    </div>
 
-                        <div class="grid_layout_page" id="grid_layout_preview">
-                            <div class="pdf_layout_page" id="pdf_on_page_layout_preview"></div>
-                        </div>
-                        <div class="overall_page" id="overall_page_layout_preview">
-                            <div class="grid_layout" id="overall_grid_preview"></div>
-                        </div>
-                        <div id="layout_offset_info">bob joe sam</div>
+                    <div class="grid_layout_page stripes_paper" id="grid_layout_preview">
+                        <div class="pdf_layout_page stripes_pdf" id="pdf_on_page_layout_preview"></div>
                     </div>
                 </span>
 

--- a/index.html
+++ b/index.html
@@ -161,31 +161,31 @@
                 </span>
 
                 <span class="row">
-                    <div style="width:225px;position: absolute;margin-left: 250px;font-size: smaller;">
+                    <div class="layout_margin_description">
                         White Space Manipulation. All values are in points, relative to original document.<BR><BR>1 point = 1/72 inch
                     </div>
-                    <div style="width:225px;margin-top:15px;margin-bottom:15px;text-align: right;">
-                        Fore-Edge Margin: <input type="number" id="main_fore_edge_padding_pt" name="main_fore_edge_padding_pt" style="width: 4em;margin-left: 10px;"><sub>pt</sub></BR>
-                        Binding Margin: <input type="number" id="binding_edge_padding_pt" name="binding_edge_padding_pt" style="width: 4em;margin-left: 10px;"><sub>pt</sub></BR>
-                        Top Margin: <input type="number" id="top_edge_padding_pt" name="top_edge_padding_pt" style="width: 4em;margin-left: 10px;"><sub>pt</sub></BR>
-                        Bottom Margin: <input type="number" id="bottom_edge_padding_pt" name="bottom_edge_padding_pt" style="width: 4em;margin-left: 10px;"><sub>pt</sub></BR>
+                    <div class="layout_margin_user_input">
+                        Fore-Edge Margin: <input type="number" id="main_fore_edge_padding_pt" name="main_fore_edge_padding_pt" class="layout_margin_user_input_field"><sub>pt</sub></BR>
+                        Binding Margin: <input type="number" id="binding_edge_padding_pt" name="binding_edge_padding_pt" class="layout_margin_user_input_field"><sub>pt</sub></BR>
+                        Top Margin: <input type="number" id="top_edge_padding_pt" name="top_edge_padding_pt"  class="layout_margin_user_input_field"><sub>pt</sub></BR>
+                        Bottom Margin: <input type="number" id="bottom_edge_padding_pt" name="bottom_edge_padding_pt"  class="layout_margin_user_input_field"><sub>pt</sub></BR>
                     </div>
                 </span>
 
                 <span class="row" id="show_layout_info">
                     <div class="layout_spine_label">spine</div>
                     <div class="layout_margin_info" id="layout_margin_info">
-                        <div class="stripes_paper" style="width:20px;height:20px;display:inline-block;"></div> 
+                        <div class="stripes_paper stripes_sample_box"></div>
                         <b>Paper/Layout Dimensions</b>
                         layout: <span id="page_grid_layout"></span><BR>
                         max page size: <span id="page_grid_dimensions"></span><BR>
                         <br>
-                        <div class="stripes_pdf" style="width:20px;height:20px;display:inline-block;"></div> 
+                        <div class="stripes_pdf stripes_sample_box"></div>
                         <b>PDF Dimensions</b><BR>
                         source: <span id="pdf_source_dimensions"></span><BR>
                         on page: <span id="pdf_page_dimensions"></span><BR>
                         scaling: <span id="pdf_scale_dimensions"></span><BR>
-                        offset: <div style="display:inline;"><div id="pdf_offset_dimensions" style="padding-left: 10px;display: inline-block;vertical-align: top;"></div></div><BR>
+                        offset: <div style="display:inline;"><div id="pdf_offset_dimensions" class="pdf_offset_dimensions_box"></div></div><BR>
                         rotated: <span id="pdf_page_rotation_info"></span><BR>
                         <BR>
                         (<i>all dimensions are in Points</i>)

--- a/preload.js
+++ b/preload.js
@@ -653,22 +653,23 @@ class Book {
      *
      * @return the object: {
      *      layoutCell: 2 dimensional array of the largest possible space the PDF page could take within the layout (and not overflow) 
-     *      pdfSize: 2 dimensional array of dimensions for the PDF page + margins
+     *      rawPdfSize: 2 dimensional array of dimensions for the PDF (pre scaled)
+     *      pdfSize: 2 dimensional array of dimensions for the PDF page + margins (pre scaled)
      *      pdfScale: 2 dimensional array of scaling factors for the raw PDF so it fits in layoutCell (w/ margins)
-     *      xForeEdgeShiftFunc: requires the page rotation, in degrees.
-     *      xBindingShiftFunc: requires the page rotation, in degrees.
-     *      xPdfWidthFunc:  requires the page rotation, in degrees.
-     *      yPdfHeightFunc: requires the page rotation, in degrees.
-     *      yTopShiftFunc:  requires the page rotation, in degrees.
-     *      yBottomShiftFunc:  requires the page rotation, in degrees.
+     *      padding: object containing the already scaled padding. Keys are: fore_edge, binding, top, bottom
+     *      xForeEdgeShiftFunc: requires the page rotation, in degrees. In pts, already scaled.
+     *      xBindingShiftFunc: requires the page rotation, in degrees. In pts, already scaled.
+     *      xPdfWidthFunc:  requires the page rotation, in degrees. In pts, already scaled.
+     *      yPdfHeightFunc: requires the page rotation, in degrees. In pts, already scaled.
+     *      yTopShiftFunc:  requires the page rotation, in degrees. In pts, already scaled.
+     *      yBottomShiftFunc:  requires the page rotation, in degrees. In pts, already scaled.
      * }
      */
     calculate_dimensions() {
         console.log("Rebecca: calculate_dimensions ")
-        let onlyPos = function(v) { 
-            return (v > 0) ? v : 0
-        }
-
+        let onlyPos = function(v) { return (v > 0) ? v : 0 }
+        let onlyNeg = function(v) { return (v < 0) ? v : 0 }
+        // PDF + margins (positive)
         let pagex = this.cropbox.width + onlyPos(this.padding_pt['binding']) + onlyPos(this.padding_pt['fore_edge']);
         let pagey = this.cropbox.height + onlyPos(this.padding_pt['top']) + onlyPos(this.padding_pt['bottom']);
 
@@ -680,10 +681,11 @@ class Book {
 
 
         // if pages are rotated a quarter-turn in this layout, we need to swap the width and height measurements
+        console.log("Rebecca: we rotating??? "+layout.landscape)
         if (layout.landscape) {
-            let temp = pagex;
-            pagex = pagey;
-            pagey = temp;
+            let temp = finalx;
+            finalx = finaly;
+            finaly = temp;
         }
 
         let sx = 1;
@@ -705,63 +707,50 @@ class Book {
             'bottom' : this.padding_pt['bottom'] * sy,
             'top' : this.padding_pt['top'] * sy
         };
-        
-        let bookheight = pagey * sy;            //       height of imposed page
-        let bookwidth = pagex * sx;             //       width of imposed page
-
-        let xpad = (finalx - bookwidth) / 2.0;        //       gap above and below imposed page
-        let ypad = (finaly - bookheight) / 2.0;            //       gap to side of imposed page
-
-        let xoffset = this.cropbox.x * sx;
-        let yoffset = this.cropbox.y * sy;
 
         // page_positioning has 2 options: centered, binding_alinged
-        let xForeEdgeShiftFunc = function(pageRotation) {
+        let positioning = this.page_positioning
+
+        let xForeEdgeShiftFunc = function() {
             // amount to inset by, relative to fore edge, on left side of book
-            let leftRightPageGap = ([90,-90].includes(pageRotation)) ? ypad : xpad;
-            return padding['fore_edge']*sx + ((this.page_positioning == 'centered' ) ? leftRightPageGap : 2 * leftRightPageGap);
+            let xgap = finalx -  pagex * sx;
+            return padding['fore_edge'] + ((positioning == 'centered' )? xgap/2 : xgap);
         }
-        let xBindingShiftFunc = function(pageRotation) {
+        let xBindingShiftFunc = function() {
             // amount to inset by, relative to binding, on right side of book
-            let leftRightPageGap = ([90,-90].includes(pageRotation)) ? ypad : xpad; 
-            return padding['binding']*sx + ((this.page_positioning == 'centered' ) ? leftRightPageGap : 0);
+            let xgap = finalx - pagex * sx;
+            return padding['binding'] + ((positioning == 'centered' )? xgap/2 : 0);
         }
-        let yTopShiftFunc = function(pageRotation) {
-            let topBottomPageGap = ([90,-90].includes(pageRotation)) ?  xpad : ypad; 
-            return padding['top']*sy + topBottomPageGap ;
+        let yTopShiftFunc = function() {
+            let ygap = finaly -  pagey * sy;
+            return padding['top'] + ygap/2 ;
         }
-        let yBottomShiftFunc = function(pageRotation) {
-            let topBottomPageGap = ([90,-90].includes(pageRotation)) ?  xpad : ypad; 
-            return padding['bottom']*sy + topBottomPageGap ;
+        let yBottomShiftFunc = function() {
+            let ygap = finaly -  pagey * sy;
+            return padding['bottom'] + ygap/2 ;
         }
-        let xPdfWidthFunc = function(pageRotation) {
-            let rawWidth = ([90,-90].includes(pageRotation)) ?  bookheight : bookwidth; 
-            return rawWidth - padding['fore_edge']*sx - padding['binding']*sx
+        let xPdfWidthFunc = function() {
+            return pagex * sx - padding['fore_edge'] - padding['binding'];
         }
-        let yPdfHeightFunc = function(pageRotation) {
-            let rawHeight = ([90,-90].includes(pageRotation)) ?  bookwidth : bookheight; 
-            return rawHeight - padding['top']*sy - padding['bottom']*sy
+        let yPdfHeightFunc = function() {
+            return pagey * sy - padding['top'] - padding['bottom'];
         }
         return {
-            ypad: ypad,
-            xpad: xpad,
-            padding: padding,
-            finalx: finalx,
-            finaly: finaly,
             layout: layout,
-            pdfOnPage: [bookwidth, bookheight],
-            sy: sy,
-            sx: sx,
+            rawPdfSize: [this.cropbox.width, this.cropbox.height],
             pdfScale: [sx, sy],
             pdfSize: [pagex, pagey],
             layoutCell: [finalx, finaly],
+            padding: padding,
+
             xForeEdgeShiftFunc: xForeEdgeShiftFunc,
             xBindingShiftFunc: xBindingShiftFunc,
             xPdfWidthFunc: xPdfWidthFunc,
             yPdfHeightFunc: yPdfHeightFunc,
             yTopShiftFunc: yTopShiftFunc,
             yBottomShiftFunc: yBottomShiftFunc,
-            page_positioning: this.page_positioning
+
+            positioning: positioning
         }
     }
 
@@ -774,42 +763,42 @@ class Book {
     calculatelayout(alt_folio){
         // vampire
         let l = this.calculate_dimensions()
+        let cellWidth = l.layoutCell[0]
+        let cellHeight = l.layoutCell[1]
         let positions = []
 
         l.layout.rotations.forEach((row, i) => {
             row.forEach((col, j) => {
-
-                let leftRightPageGap = ([90,-90].includes(col)) ? l.ypad : l.xpad;
-
-                let xForeEdgeShift = l.xForeEdgeShiftFunc(col);
-                let xBindingShift = l.xBindingShiftFunc(col);
+                let xForeEdgeShift = l.xForeEdgeShiftFunc();
+                let xBindingShift = l.xBindingShiftFunc();
+                let yTopShift = l.yTopShiftFunc();
+                let yBottomShift = l.yBottomShiftFunc();
 
                 let isLeftPage = j % 2 == 0; //page on 'left' side of open book
-                let x = (j * l.finalx) + ((isLeftPage) ? xForeEdgeShift : xBindingShift);
-                let y = (i * l.finaly) + l.ypad + l.padding['bottom'] * l.sy;
+                let x = (j * cellWidth) + ((isLeftPage) ? xForeEdgeShift : xBindingShift);
+                let y = (i * cellHeight) + yBottomShift;
 
                 if ([-180].includes(col)) { // upside-down page
-                    let isLeftPage = j % 2 == 1; //page on 'left' (right side on screen)
-                    y = l.finaly + (i * l.finaly) - l.ypad - l.padding['bottom'] * l.sy;
-                    x = l.finalx + (j * l.finalx) - ((isLeftPage) ? xBindingShift : xForeEdgeShift);
-                }
+                    isLeftPage = j % 2 == 1; //page on 'left' (right side on screen)
+                    y = (i + 1) * cellHeight - yBottomShift;
+                    x = (j + 1) * cellWidth - ((isLeftPage) ? xForeEdgeShift : xBindingShift);
 
-                if ([90].includes(col)) {   // 'top' of page is on left, right side of screen
-                    let isLeftPage = i % 2 == 0; // page is on 'left' (top side of screen)
-                    x = (1 + j) * l.finalx - l.padding['bottom'] - l.xpad;// + padding['top'];
-                    y = (i * l.finaly) + ((isLeftPage) ? xForeEdgeShift : xBindingShift);
-                }
-                if ([-90].includes(col)) {  // 'top' of page is on the right, left sight of screen
-                    let isLeftPage = i % 2 == 1; // page is on 'left' (bottom side of screen)
-                    x = j * l.finalx + l.padding['bottom'] + l.xpad;
-                    y = ((1+i) * l.finaly) - ((isLeftPage) ? xForeEdgeShift : xBindingShift);
+                } else if ([90].includes(col)) {   // 'top' of page is on left, right side of screen
+                    isLeftPage = i % 2 == 0; // page is on 'left' (top side of screen)
+                    x = (1 + j) * cellHeight - yBottomShift;
+                    y = (1 + i) * cellWidth + ((isLeftPage) ? xBindingShift : xForeEdgeShift);
+
+                } else if ([-90].includes(col)) {  // 'top' of page is on the right, left sight of screen
+                    isLeftPage = i % 2 == 1; // page is on 'left' (bottom side of screen)
+                    x = j * cellHeight + yBottomShift;
+                    y = (1+i) * cellWidth - ((isLeftPage) ? xForeEdgeShift : xBindingShift);
                 }
 
                 console.log(">> (", i, ",",j,")[",col,"] : [",x,", ",y,"] :: [xForeEdgeShift: ",xForeEdgeShift,"][xBindingShift: ",xBindingShift,"]");
-                positions.push({rotation: col, sx: l.sx, sy: l.sy, x: x, y: y})
+                positions.push({rotation: col, sx: l.pdfScale[0], sy: l.pdfScale[1], x: x, y: y})
             })
         })
-        console.log("And in the end of it all, (calculatelayout) we get: ",positions)
+        console.log("Rebecca And in the end of it all, (calculatelayout) we get: ",positions)
         return positions;
     }
 
@@ -31710,12 +31699,9 @@ function updatePageLayoutInfo(info) {
   document.getElementById("show_layout_info").style.display = 'block'
   console.log("So much info from updatePageLayoutInfo: ", info)
   let needsRotation = info.dimensions.layout.rotations[0] == -90 || info.dimensions.layout.rotations[0] == 90 ||  info.dimensions.layout.rotations[0][0] == -90 ||  info.dimensions.layout.rotations[0][0] == 90  
-  let basicRotationInDegs = (needsRotation) ? 90 : 0
   //   Paper size: ${info.papersize[0]}, ${info.papersize[1]}<BR>
-  let paperDims = [info.dimensions.finalx, info.dimensions.finaly]
-  if (needsRotation) paperDims.reverse()
-  let pdfDims = [info.dimensions.xPdfWidthFunc(basicRotationInDegs), info.dimensions.yPdfHeightFunc(basicRotationInDegs)]
-  let pdfScale = [info.dimensions.sx, info.dimensions.sy]
+  let paperDims = info.dimensions.layoutCell
+  let pdfDims = [info.dimensions.xPdfWidthFunc(), info.dimensions.yPdfHeightFunc()]
 
   let scale = Math.min(Math.min(250/paperDims[0], 250/paperDims[1]), Math.min(250/pdfDims[0], 250/pdfDims[1]))
   
@@ -31729,15 +31715,20 @@ function updatePageLayoutInfo(info) {
   displayDiv.style.width = `${dims[0]}px`
   displayDiv.style.height = `${dims[1]}px`
 
-  dims = [info.dimensions.xBindingShiftFunc(basicRotationInDegs) * scale, info.dimensions.yTopShiftFunc(basicRotationInDegs) * scale]
+  dims = [info.dimensions.xBindingShiftFunc() * scale, info.dimensions.yTopShiftFunc() * scale]
   displayDiv.style.margin = `${dims[1]}px ${dims[0]}px`
 
   document.getElementById("page_grid_layout").innerText = `${info.dimensions.layout.rows} rows x ${info.dimensions.layout.cols} cols`
   document.getElementById("page_grid_dimensions").innerText = `${paperDims[0]}, ${paperDims[1]}`
   document.getElementById("pdf_source_dimensions").innerText = `${info.cropbox.width}, ${info.cropbox.height}`
   document.getElementById("pdf_page_dimensions").innerText = `${pdfDims[0].toFixed(2)}, ${pdfDims[1].toFixed(2)}`
-  document.getElementById("pdf_offset_dimensions").innerText = `${info.dimensions.xBindingShiftFunc(basicRotationInDegs).toFixed(2)} from spine, ${info.dimensions.yTopShiftFunc(basicRotationInDegs).toFixed(2)} from top`
-  document.getElementById("pdf_scale_dimensions").innerText = `${pdfScale[0].toFixed(2)}, ${pdfScale[1].toFixed(2)}`
+  document.getElementById("pdf_offset_dimensions").innerHTML = `
+  ${info.dimensions.xBindingShiftFunc().toFixed(2)} from spine <BR>
+  ${info.dimensions.yTopShiftFunc().toFixed(2)} from top <BR>
+  ${info.dimensions.xForeEdgeShiftFunc().toFixed(2)} from fore edge <BR>
+  ${info.dimensions.yBottomShiftFunc().toFixed(2)} from bottom
+  `
+  document.getElementById("pdf_scale_dimensions").innerText = `${info.dimensions.pdfScale[0].toFixed(2)}, ${info.dimensions.pdfScale[1].toFixed(2)}`
   document.getElementById("pdf_page_rotation_info").innerText = `${needsRotation}`
   document.getElementById("layout_debug_info").innerHTML = ``
   

--- a/preload.js
+++ b/preload.js
@@ -666,7 +666,6 @@ class Book {
      * }
      */
     calculate_dimensions() {
-        console.log("Rebecca: calculate_dimensions ")
         let onlyPos = function(v) { return (v > 0) ? v : 0 }
         let onlyNeg = function(v) { return (v < 0) ? v : 0 }
         // PDF + margins (positive)
@@ -681,7 +680,6 @@ class Book {
 
 
         // if pages are rotated a quarter-turn in this layout, we need to swap the width and height measurements
-        console.log("Rebecca: we rotating??? "+layout.landscape)
         if (layout.landscape) {
             let temp = finalx;
             finalx = finaly;
@@ -786,7 +784,7 @@ class Book {
                 } else if ([90].includes(col)) {   // 'top' of page is on left, right side of screen
                     isLeftPage = i % 2 == 0; // page is on 'left' (top side of screen)
                     x = (1 + j) * cellHeight - yBottomShift;
-                    y = (1 + i) * cellWidth + ((isLeftPage) ? xBindingShift : xForeEdgeShift);
+                    y = i * cellWidth + ((isLeftPage) ? xBindingShift : xForeEdgeShift);
 
                 } else if ([-90].includes(col)) {  // 'top' of page is on the right, left sight of screen
                     isLeftPage = i % 2 == 1; // page is on 'left' (bottom side of screen)
@@ -798,7 +796,7 @@ class Book {
                 positions.push({rotation: col, sx: l.pdfScale[0], sy: l.pdfScale[1], x: x, y: y})
             })
         })
-        console.log("Rebecca And in the end of it all, (calculatelayout) we get: ",positions)
+        console.log("And in the end of it all, (calculatelayout) we get: ",positions)
         return positions;
     }
 
@@ -31730,9 +31728,6 @@ function updatePageLayoutInfo(info) {
   `
   document.getElementById("pdf_scale_dimensions").innerText = `${info.dimensions.pdfScale[0].toFixed(2)}, ${info.dimensions.pdfScale[1].toFixed(2)}`
   document.getElementById("pdf_page_rotation_info").innerText = `${needsRotation}`
-  document.getElementById("layout_debug_info").innerHTML = ``
-  
-  
 }
 /**
  * Expects a data object describing the overall page layout info:

--- a/preload.js
+++ b/preload.js
@@ -645,7 +645,7 @@ class Book {
     }
 
     /**
-     * Looks at [this.cripbox] and [this.padding_pt] and [this.papersize] and [this.page_layout] and [this.page_scaling]
+     * Looks at [this.cropbox] and [this.padding_pt] and [this.papersize] and [this.page_layout] and [this.page_scaling]
      * in order to calculate the information needed to render a PDF page within a layout cell. It provides several functions
      * in the return object that calculate the positioning and scaling needed when provided the rotation information.
      *
@@ -776,17 +776,17 @@ class Book {
                 let x = (j * cellWidth) + ((isLeftPage) ? xForeEdgeShift : xBindingShift);
                 let y = (i * cellHeight) + yBottomShift;
 
-                if ([-180].includes(col)) { // upside-down page
+                if (col == -180) { // upside-down page
                     isLeftPage = j % 2 == 1; //page on 'left' (right side on screen)
                     y = (i + 1) * cellHeight - yBottomShift;
                     x = (j + 1) * cellWidth - ((isLeftPage) ? xForeEdgeShift : xBindingShift);
 
-                } else if ([90].includes(col)) {   // 'top' of page is on left, right side of screen
+                } else if (col == 90) {   // 'top' of page is on left, right side of screen
                     isLeftPage = i % 2 == 0; // page is on 'left' (top side of screen)
                     x = (1 + j) * cellHeight - yBottomShift;
                     y = i * cellWidth + ((isLeftPage) ? xBindingShift : xForeEdgeShift);
 
-                } else if ([-90].includes(col)) {  // 'top' of page is on the right, left sight of screen
+                } else if (col == -90) {  // 'top' of page is on the right, left sight of screen
                     isLeftPage = i % 2 == 1; // page is on 'left' (bottom side of screen)
                     x = j * cellHeight + yBottomShift;
                     y = (1+i) * cellWidth - ((isLeftPage) ? xForeEdgeShift : xBindingShift);

--- a/src/book.js
+++ b/src/book.js
@@ -644,7 +644,6 @@ export class Book {
      * }
      */
     calculate_dimensions() {
-        console.log("Rebecca: calculate_dimensions ")
         let onlyPos = function(v) { return (v > 0) ? v : 0 }
         let onlyNeg = function(v) { return (v < 0) ? v : 0 }
         // PDF + margins (positive)
@@ -659,7 +658,6 @@ export class Book {
 
 
         // if pages are rotated a quarter-turn in this layout, we need to swap the width and height measurements
-        console.log("Rebecca: we rotating??? "+layout.landscape)
         if (layout.landscape) {
             let temp = finalx;
             finalx = finaly;
@@ -764,7 +762,7 @@ export class Book {
                 } else if ([90].includes(col)) {   // 'top' of page is on left, right side of screen
                     isLeftPage = i % 2 == 0; // page is on 'left' (top side of screen)
                     x = (1 + j) * cellHeight - yBottomShift;
-                    y = (1 + i) * cellWidth + ((isLeftPage) ? xBindingShift : xForeEdgeShift);
+                    y = i * cellWidth + ((isLeftPage) ? xBindingShift : xForeEdgeShift);
 
                 } else if ([-90].includes(col)) {  // 'top' of page is on the right, left sight of screen
                     isLeftPage = i % 2 == 1; // page is on 'left' (bottom side of screen)
@@ -776,7 +774,7 @@ export class Book {
                 positions.push({rotation: col, sx: l.pdfScale[0], sy: l.pdfScale[1], x: x, y: y})
             })
         })
-        console.log("Rebecca And in the end of it all, (calculatelayout) we get: ",positions)
+        console.log("And in the end of it all, (calculatelayout) we get: ",positions)
         return positions;
     }
 

--- a/src/book.js
+++ b/src/book.js
@@ -623,7 +623,7 @@ export class Book {
     }
 
     /**
-     * Looks at [this.cripbox] and [this.padding_pt] and [this.papersize] and [this.page_layout] and [this.page_scaling]
+     * Looks at [this.cropbox] and [this.padding_pt] and [this.papersize] and [this.page_layout] and [this.page_scaling]
      * in order to calculate the information needed to render a PDF page within a layout cell. It provides several functions
      * in the return object that calculate the positioning and scaling needed when provided the rotation information.
      *
@@ -754,17 +754,17 @@ export class Book {
                 let x = (j * cellWidth) + ((isLeftPage) ? xForeEdgeShift : xBindingShift);
                 let y = (i * cellHeight) + yBottomShift;
 
-                if ([-180].includes(col)) { // upside-down page
+                if (col == -180) { // upside-down page
                     isLeftPage = j % 2 == 1; //page on 'left' (right side on screen)
                     y = (i + 1) * cellHeight - yBottomShift;
                     x = (j + 1) * cellWidth - ((isLeftPage) ? xForeEdgeShift : xBindingShift);
 
-                } else if ([90].includes(col)) {   // 'top' of page is on left, right side of screen
+                } else if (col == 90) {   // 'top' of page is on left, right side of screen
                     isLeftPage = i % 2 == 0; // page is on 'left' (top side of screen)
                     x = (1 + j) * cellHeight - yBottomShift;
                     y = i * cellWidth + ((isLeftPage) ? xBindingShift : xForeEdgeShift);
 
-                } else if ([-90].includes(col)) {  // 'top' of page is on the right, left sight of screen
+                } else if (col == -90) {  // 'top' of page is on the right, left sight of screen
                     isLeftPage = i % 2 == 1; // page is on 'left' (bottom side of screen)
                     x = j * cellHeight + yBottomShift;
                     y = (1+i) * cellWidth - ((isLeftPage) ? xForeEdgeShift : xBindingShift);

--- a/src/utils/renderUtils.js
+++ b/src/utils/renderUtils.js
@@ -33,12 +33,9 @@ export function updatePageLayoutInfo(info) {
   document.getElementById("show_layout_info").style.display = 'block'
   console.log("So much info from updatePageLayoutInfo: ", info)
   let needsRotation = info.dimensions.layout.rotations[0] == -90 || info.dimensions.layout.rotations[0] == 90 ||  info.dimensions.layout.rotations[0][0] == -90 ||  info.dimensions.layout.rotations[0][0] == 90  
-  let basicRotationInDegs = (needsRotation) ? 90 : 0
   //   Paper size: ${info.papersize[0]}, ${info.papersize[1]}<BR>
-  let paperDims = [info.dimensions.finalx, info.dimensions.finaly]
-  if (needsRotation) paperDims.reverse()
-  let pdfDims = [info.dimensions.xPdfWidthFunc(basicRotationInDegs), info.dimensions.yPdfHeightFunc(basicRotationInDegs)]
-  let pdfScale = [info.dimensions.sx, info.dimensions.sy]
+  let paperDims = info.dimensions.layoutCell
+  let pdfDims = [info.dimensions.xPdfWidthFunc(), info.dimensions.yPdfHeightFunc()]
 
   let scale = Math.min(Math.min(250/paperDims[0], 250/paperDims[1]), Math.min(250/pdfDims[0], 250/pdfDims[1]))
   
@@ -52,15 +49,20 @@ export function updatePageLayoutInfo(info) {
   displayDiv.style.width = `${dims[0]}px`
   displayDiv.style.height = `${dims[1]}px`
 
-  dims = [info.dimensions.xBindingShiftFunc(basicRotationInDegs) * scale, info.dimensions.yTopShiftFunc(basicRotationInDegs) * scale]
+  dims = [info.dimensions.xBindingShiftFunc() * scale, info.dimensions.yTopShiftFunc() * scale]
   displayDiv.style.margin = `${dims[1]}px ${dims[0]}px`
 
   document.getElementById("page_grid_layout").innerText = `${info.dimensions.layout.rows} rows x ${info.dimensions.layout.cols} cols`
   document.getElementById("page_grid_dimensions").innerText = `${paperDims[0]}, ${paperDims[1]}`
   document.getElementById("pdf_source_dimensions").innerText = `${info.cropbox.width}, ${info.cropbox.height}`
   document.getElementById("pdf_page_dimensions").innerText = `${pdfDims[0].toFixed(2)}, ${pdfDims[1].toFixed(2)}`
-  document.getElementById("pdf_offset_dimensions").innerText = `${info.dimensions.xBindingShiftFunc(basicRotationInDegs).toFixed(2)} from spine, ${info.dimensions.yTopShiftFunc(basicRotationInDegs).toFixed(2)} from top`
-  document.getElementById("pdf_scale_dimensions").innerText = `${pdfScale[0].toFixed(2)}, ${pdfScale[1].toFixed(2)}`
+  document.getElementById("pdf_offset_dimensions").innerHTML = `
+  ${info.dimensions.xBindingShiftFunc().toFixed(2)} from spine <BR>
+  ${info.dimensions.yTopShiftFunc().toFixed(2)} from top <BR>
+  ${info.dimensions.xForeEdgeShiftFunc().toFixed(2)} from fore edge <BR>
+  ${info.dimensions.yBottomShiftFunc().toFixed(2)} from bottom
+  `
+  document.getElementById("pdf_scale_dimensions").innerText = `${info.dimensions.pdfScale[0].toFixed(2)}, ${info.dimensions.pdfScale[1].toFixed(2)}`
   document.getElementById("pdf_page_rotation_info").innerText = `${needsRotation}`
   document.getElementById("layout_debug_info").innerHTML = ``
   

--- a/src/utils/renderUtils.js
+++ b/src/utils/renderUtils.js
@@ -25,7 +25,52 @@ export function renderInfoBox(book) {
     totalPages.innerText = outputPages;
 }
 
+/**
+ * Expects a data object describing the overall page layout info:
+ *
+ */
+export function updatePageLayoutInfo(info) {
+  console.log("So much info from updatePageLayoutInfo: ", info)
+  let d = document.getElementById('layout_margin_info')
+  let needsRotation = info.dimensions.layout.rotations[0] == -90 || info.dimensions.layout.rotations[0] == 90 ||  info.dimensions.layout.rotations[0][0] == -90 ||  info.dimensions.layout.rotations[0][0] == 90  
+  d.innerHTML = `
+    Paper size: ${info.papersize[0]}, ${info.papersize[1]}<BR>
+    Source PDF dimensions: ${info.cropbox.width}, ${info.cropbox.height}<BR>
+    Subdivided into ${info.dimensions.layout.rows} rows x ${info.dimensions.layout.cols} cols<BR>
+    Grid cell dimensions: ${info.dimensions.finalx}, ${info.dimensions.finaly}<BR>
+    Pages rotated: ${needsRotation}
+  `
+  console.log("Needs rotation? : "+needsRotation)
+  let scale = Math.min(250/info.papersize[0], 250/info.papersize[1])
+  let dims = [info.papersize[0] * scale, info.papersize[1] * scale]
+  let pp = document.getElementById("overall_page_layout_preview")
+  pp.style.width = `${dims[0]}px`
+  pp.style.height = `${dims[1]}px`
+  dims = [info.dimensions.finalx * info.dimensions.layout.cols * scale, info.dimensions.finaly * info.dimensions.layout.rows * scale]
+  pp = document.getElementById("overall_grid_preview")
+  pp.style.width = `${dims[0]}px`
+  pp.style.height = `${dims[1]}px`
 
+  scale = Math.min(250/info.dimensions.finalx, 250/info.dimensions.finaly)
+  dims = [info.dimensions.finalx * scale, info.dimensions.finaly * scale]
+ if (needsRotation) dims.reverse()
+  pp = document.getElementById("grid_layout_preview")
+  pp.style.width = `${dims[0]}px`
+  pp.style.height = `${dims[1]}px`
+
+  dims = [info.dimensions.pdfOnPage[0]  * scale, info.dimensions.pdfOnPage[1] * scale]
+  pp = document.getElementById("pdf_on_page_layout_preview")
+  if (needsRotation) dims.reverse()
+  pp.style.width = `${dims[0]}px`
+  pp.style.height = `${dims[1]}px`
+  dims = [info.dimensions.xpad * scale, info.dimensions.ypad * scale]
+  if (!needsRotation) dims.reverse()
+  pp.style.margin = `${dims[0]}px ${dims[1]}px`
+}
+/**
+ * Expects a data object describing the overall page layout info:
+ *
+ */
 export function updatePaperSelectOptionsUnits() {
     const paperList = document.getElementById('paper_size');
     const paperListUnit = document.getElementById('paper_size_unit').value

--- a/src/utils/renderUtils.js
+++ b/src/utils/renderUtils.js
@@ -30,42 +30,41 @@ export function renderInfoBox(book) {
  *
  */
 export function updatePageLayoutInfo(info) {
+  document.getElementById("show_layout_info").style.display = 'block'
   console.log("So much info from updatePageLayoutInfo: ", info)
-  let d = document.getElementById('layout_margin_info')
   let needsRotation = info.dimensions.layout.rotations[0] == -90 || info.dimensions.layout.rotations[0] == 90 ||  info.dimensions.layout.rotations[0][0] == -90 ||  info.dimensions.layout.rotations[0][0] == 90  
-  d.innerHTML = `
-    Paper size: ${info.papersize[0]}, ${info.papersize[1]}<BR>
-    Source PDF dimensions: ${info.cropbox.width}, ${info.cropbox.height}<BR>
-    Subdivided into ${info.dimensions.layout.rows} rows x ${info.dimensions.layout.cols} cols<BR>
-    Grid cell dimensions: ${info.dimensions.finalx}, ${info.dimensions.finaly}<BR>
-    Pages rotated: ${needsRotation}
-  `
-  console.log("Needs rotation? : "+needsRotation)
-  let scale = Math.min(250/info.papersize[0], 250/info.papersize[1])
-  let dims = [info.papersize[0] * scale, info.papersize[1] * scale]
-  let pp = document.getElementById("overall_page_layout_preview")
-  pp.style.width = `${dims[0]}px`
-  pp.style.height = `${dims[1]}px`
-  dims = [info.dimensions.finalx * info.dimensions.layout.cols * scale, info.dimensions.finaly * info.dimensions.layout.rows * scale]
-  pp = document.getElementById("overall_grid_preview")
-  pp.style.width = `${dims[0]}px`
-  pp.style.height = `${dims[1]}px`
+  let basicRotationInDegs = (needsRotation) ? 90 : 0
+  //   Paper size: ${info.papersize[0]}, ${info.papersize[1]}<BR>
+  let paperDims = [info.dimensions.finalx, info.dimensions.finaly]
+  if (needsRotation) paperDims.reverse()
+  let pdfDims = [info.dimensions.xPdfWidthFunc(basicRotationInDegs), info.dimensions.yPdfHeightFunc(basicRotationInDegs)]
+  let pdfScale = [info.dimensions.sx, info.dimensions.sy]
 
-  scale = Math.min(250/info.dimensions.finalx, 250/info.dimensions.finaly)
-  dims = [info.dimensions.finalx * scale, info.dimensions.finaly * scale]
- if (needsRotation) dims.reverse()
-  pp = document.getElementById("grid_layout_preview")
-  pp.style.width = `${dims[0]}px`
-  pp.style.height = `${dims[1]}px`
+  let scale = Math.min(Math.min(250/paperDims[0], 250/paperDims[1]), Math.min(250/pdfDims[0], 250/pdfDims[1]))
+  
+  let dims = [paperDims[0] * scale, paperDims[1] * scale]
+  let displayDiv = document.getElementById("grid_layout_preview") // blue box
+  displayDiv.style.width = `${dims[0]}px`
+  displayDiv.style.height = `${dims[1]}px`
 
-  dims = [info.dimensions.pdfOnPage[0]  * scale, info.dimensions.pdfOnPage[1] * scale]
-  pp = document.getElementById("pdf_on_page_layout_preview")
-  if (needsRotation) dims.reverse()
-  pp.style.width = `${dims[0]}px`
-  pp.style.height = `${dims[1]}px`
-  dims = [info.dimensions.xpad * scale, info.dimensions.ypad * scale]
-  if (!needsRotation) dims.reverse()
-  pp.style.margin = `${dims[0]}px ${dims[1]}px`
+  dims = [pdfDims[0] * scale, pdfDims[1] * scale]
+  displayDiv = document.getElementById("pdf_on_page_layout_preview")  // orange box
+  displayDiv.style.width = `${dims[0]}px`
+  displayDiv.style.height = `${dims[1]}px`
+
+  dims = [info.dimensions.xBindingShiftFunc(basicRotationInDegs) * scale, info.dimensions.yTopShiftFunc(basicRotationInDegs) * scale]
+  displayDiv.style.margin = `${dims[1]}px ${dims[0]}px`
+
+  document.getElementById("page_grid_layout").innerText = `${info.dimensions.layout.rows} rows x ${info.dimensions.layout.cols} cols`
+  document.getElementById("page_grid_dimensions").innerText = `${paperDims[0]}, ${paperDims[1]}`
+  document.getElementById("pdf_source_dimensions").innerText = `${info.cropbox.width}, ${info.cropbox.height}`
+  document.getElementById("pdf_page_dimensions").innerText = `${pdfDims[0].toFixed(2)}, ${pdfDims[1].toFixed(2)}`
+  document.getElementById("pdf_offset_dimensions").innerText = `${info.dimensions.xBindingShiftFunc(basicRotationInDegs).toFixed(2)} from spine, ${info.dimensions.yTopShiftFunc(basicRotationInDegs).toFixed(2)} from top`
+  document.getElementById("pdf_scale_dimensions").innerText = `${pdfScale[0].toFixed(2)}, ${pdfScale[1].toFixed(2)}`
+  document.getElementById("pdf_page_rotation_info").innerText = `${needsRotation}`
+  document.getElementById("layout_debug_info").innerHTML = ``
+  
+  
 }
 /**
  * Expects a data object describing the overall page layout info:

--- a/src/utils/renderUtils.js
+++ b/src/utils/renderUtils.js
@@ -64,9 +64,6 @@ export function updatePageLayoutInfo(info) {
   `
   document.getElementById("pdf_scale_dimensions").innerText = `${info.dimensions.pdfScale[0].toFixed(2)}, ${info.dimensions.pdfScale[1].toFixed(2)}`
   document.getElementById("pdf_page_rotation_info").innerText = `${needsRotation}`
-  document.getElementById("layout_debug_info").innerHTML = ``
-  
-  
 }
 /**
  * Expects a data object describing the overall page layout info:

--- a/styles.css
+++ b/styles.css
@@ -66,6 +66,7 @@ body, .wrapper, #bookbinder {
 #show_layout_info {
     display: none;
     margin-left: 10px;
+    margin-bottom: 20px;
 }
 .layout_spine_label {
     transform: rotate(-90deg);

--- a/styles.css
+++ b/styles.css
@@ -62,3 +62,44 @@ body, .wrapper, #bookbinder {
 .instruction-indent {
     margin-left:  25px;
 }
+
+.show_layout_info {
+    border: 1px solid black;
+    pointer-events: none;
+}
+.overall_page {
+    border: 1px solid red;
+    width: 150px;
+    height: 150px;
+    margin-left: 10%;
+    background: #ff00004d;
+    padding-left: 20px;
+    padding-top: 6px;
+    padding-right: 20px;
+    padding-bottom: 60px;
+    pointer-events: none;
+}
+.grid_layout {
+    border: 1px solid blue;
+    background: #0000ff54;
+    pointer-events: none;
+}
+.grid_layout_page {
+    border: 1px solid purple;
+    width: 150px;
+    height: 20px;
+    margin-left: 250px;
+    background: #80008063;
+    position: absolute;
+    pointer-events: none;
+}
+.pdf_layout_page {
+    border: 1px solid orange;
+    width: 20px;
+    height: 20px;
+    position: absolute;
+    margin: 0px;
+    padding: 0px;
+    background: #ffa50042;
+    pointer-events: none;
+}

--- a/styles.css
+++ b/styles.css
@@ -63,6 +63,23 @@ body, .wrapper, #bookbinder {
     margin-left:  25px;
 }
 
+.layout_margin_user_input {
+    width:225px;
+    margin-top:15px;
+    margin-bottom:15px;
+    text-align: right;
+}
+.layout_margin_user_input_field {
+    width: 4em;
+    margin-left: 10px;
+}
+.layout_margin_description {
+    width:225px;
+    position: absolute;
+    margin-left: 250px;
+    font-size: smaller;
+}
+
 #show_layout_info {
     display: none;
     margin-left: 10px;
@@ -120,4 +137,14 @@ body, .wrapper, #bookbinder {
         #ff9800 10px,
         #FF9800 15px
     );
+}
+.stripes_sample_box {
+    width:20px;
+    height:20px;
+    display:inline-block;
+}
+.pdf_offset_dimensions_box {
+    padding-left: 10px;
+    display: inline-block;
+    vertical-align: top;
 }

--- a/styles.css
+++ b/styles.css
@@ -63,43 +63,60 @@ body, .wrapper, #bookbinder {
     margin-left:  25px;
 }
 
-.show_layout_info {
-    border: 1px solid black;
-    pointer-events: none;
+#show_layout_info {
+    display: none;
+    margin-left: 10px;
 }
-.overall_page {
-    border: 1px solid red;
-    width: 150px;
-    height: 150px;
-    margin-left: 10%;
-    background: #ff00004d;
-    padding-left: 20px;
-    padding-top: 6px;
-    padding-right: 20px;
-    padding-bottom: 60px;
-    pointer-events: none;
-}
-.grid_layout {
-    border: 1px solid blue;
-    background: #0000ff54;
-    pointer-events: none;
+.layout_spine_label {
+    transform: rotate(-90deg);
+    position: absolute;
+    text-align: center;
+    padding: 0px;
+    height: 40px;
+    margin: 105px -123px;
+    width: 250px;
+    font-family: monospace;
+    letter-spacing: 14px;
 }
 .grid_layout_page {
     border: 1px solid purple;
-    width: 150px;
-    height: 20px;
-    margin-left: 250px;
+    width: 250px;
+    height: 250px;
+    margin-left: 0px;
     background: #80008063;
-    position: absolute;
     pointer-events: none;
 }
 .pdf_layout_page {
     border: 1px solid orange;
-    width: 20px;
-    height: 20px;
+    width: 150px;
+    height: 24px;
     position: absolute;
     margin: 0px;
     padding: 0px;
     background: #ffa50042;
     pointer-events: none;
+}
+.layout_margin_info {
+    position: absolute;
+    padding-left: 255px;
+    width: 480px;
+    font-size: small;
+}
+.stripes_paper{
+    background: repeating-linear-gradient(
+        45deg,
+        #606dbc,
+        #606dbc 10px,
+        #465298 10px,
+        #465298 20px
+    );
+}
+.stripes_pdf {
+    background: repeating-linear-gradient(
+        133deg,
+        #ffeb3b3b,
+        #ffc1078c 10px,
+        #ff9800 10px,
+        #FF9800 15px
+    );
 }


### PR DESCRIPTION
This PR is to help users better understand how their page is going to be laid out, _before_ we even hit the Preview of PDF step. There's now an info section that pops up & updates with the form showing how a PDF page will be positioned & scaled within a layout cell. Also audited/corrected page positioning/scaling/margin behavior.
(related to #53 )
[Link to test our PR](https://htmlpreview.github.io/?https://github.com/momijizukamori/bookbinder-js/blob/six_squares/index.html)

This only (currently) effects/works with the "Classic" layouts

Changes:
- bumped version to 1.1.0
- added preview to the Page Layout section
- corrected margin & page positioning behavior


## Examples

**Basic Octavo layout**
<img width="400" alt="Screen Shot 2023-09-20 at 4 02 59 PM" src="https://github.com/momijizukamori/bookbinder-js/assets/1319240/5376b18d-37a9-4c35-8864-07803861cc2d"><img width="400" alt="Screen Shot 2023-09-20 at 4 12 58 PM" src="https://github.com/momijizukamori/bookbinder-js/assets/1319240/fb4f730c-30ac-46fc-bf2c-bbc4b031e712">

**Square Sexto, against the spine with margin on bottom**
<img width="400" alt="Screen Shot 2023-09-20 at 4 17 39 PM" src="https://github.com/momijizukamori/bookbinder-js/assets/1319240/39885a25-e8db-4952-a98f-6ae11ebeb8c0"><img width="400" alt="Screen Shot 2023-09-20 at 4 17 54 PM" src="https://github.com/momijizukamori/bookbinder-js/assets/1319240/6195d893-458f-4cdb-8d6a-4bce2077275e">

**Square Sexto, centered with margin on top**

<img width="400" alt="Screen Shot 2023-09-20 at 4 18 28 PM" src="https://github.com/momijizukamori/bookbinder-js/assets/1319240/4ee89503-e96d-4e43-ade0-b6f78fc884c0"><img width="400" alt="Screen Shot 2023-09-20 at 4 18 09 PM" src="https://github.com/momijizukamori/bookbinder-js/assets/1319240/619ca15e-44d2-45fb-b939-60ce92dc5933">


