### PR TITLE
Allow more than one flyleaf with freeform input

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,9 +222,9 @@
             </div>
 
             <div class="section" id="flyleaf_info">
-                <h2>Flyleaf</h2>
-                <span class="row"> <label>Add flyleaf <input type="checkbox" name="flyleaf"></label>
-                    <span data-balloon-length="medium" aria-label="An extra blank page at the start and end of the book" data-balloon-pos="up">ℹ️</span>
+                <h2>Flyleafs</h2>
+                <span class="row"> <label>Add flyleafs <input type="number" name="flyleafs" value="1"></label>
+                    <span data-balloon-length="medium" aria-label="Extra blank pages at the start and end of the book" data-balloon-pos="up">ℹ️</span>
                 </span> 
 
             </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookbinder",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "An app to rearrange PDF pages for printing for bookbinding",
   "type": "module",
   "scripts": {

--- a/src/book.js
+++ b/src/book.js
@@ -51,7 +51,7 @@ export class Book {
         this.print_file = configuration.printFile;
         this.page_scaling = configuration.pageScaling;
         this.page_positioning = configuration.pagePositioning;
-        this.flyleaf = configuration.flyleaf;
+        this.flyleafs = configuration.flyleafs;
         this.cropmarks = configuration.cropMarks;
         this.cutmarks = configuration.cutMarks;
         this.format = configuration.sigFormat;
@@ -119,7 +119,7 @@ export class Book {
         this.pagecount = this.currentdoc.getPageCount();
         this.orderedpages = Array.from({ length: this.pagecount }, (x, i) => i);
 
-        if (this.flyleaf) {
+        for (let i = 0; i < this.flyleafs; i++) {
             this.orderedpages.unshift('b');
             this.orderedpages.unshift('b');
 

--- a/src/book.test.js
+++ b/src/book.test.js
@@ -13,7 +13,7 @@ describe("Book model", () => {
         duplex: true,
         duplexrotate: false,
         papersize: [595, 842],
-        flyleaf: false,
+        flyleafs: 1,
         spineoffset: false,
         format: "standardsig",
         sigsize: 4,

--- a/src/models/configuration.js
+++ b/src/models/configuration.js
@@ -76,7 +76,7 @@ export const schema = z.object({
     customSigLength: urlSafe(commaSeparatedNumberList).default([]), // Specific to custom.
     foreEdgePaddingPt: urlSafe(z.coerce.number()).default(0), // specific to wacky small
     wackySpacing, // specific to wacky small
-    flyleaf: urlSafe(coercedBoolean).default(false),
+    flyleafs: urlSafe(z.coerce.number()).default(1),
     paperSizeCustomWidth: urlSafe(z.coerce.number()),
     paperSizeCustomHeight: urlSafe(z.coerce.number()),
 });

--- a/src/utils/formUtils.js
+++ b/src/utils/formUtils.js
@@ -36,7 +36,7 @@ const fromFormToConfiguration = (form) =>
         wackySpacing: form.get("wacky_spacing"),
         fileDownload: form.get("file_download"),
         printFile: form.get("print_file"),
-        flyleaf: form.has("flyleaf"),
+        flyleafs: form.get("flyleafs"),
         paperSizeCustomWidth: form.get("paper_size_custom_width"),
         paperSizeCustomHeight: form.get("paper_size_custom_height"),
     });

--- a/src/utils/renderUtils.js
+++ b/src/utils/renderUtils.js
@@ -163,10 +163,6 @@ export function renderFormFromSettings(configuration) {
         document.querySelector("input[name='rotate_page']").checked = true;
     }
 
-    if (configuration.flyleaf) {
-        document.querySelector("input[name='flyleaf']").checked = true;
-    }
-
     if (configuration.cropMarks) {
         document.querySelector("input[name='cropmarks']").checked = true;
     }
@@ -187,6 +183,7 @@ export function renderFormFromSettings(configuration) {
     document.querySelector('input[name="top_edge_padding_pt"]').value = configuration.topEdgePaddingPt;
     document.querySelector('input[name="bottom_edge_padding_pt"]').value = configuration.bottomEdgePaddingPt;
     document.querySelector('input[name="fore_edge_padding_pt"]').value = configuration.foreEdgePaddingPt;
+    document.querySelector('input[name="flyleafs"]').value = configuration.flyleafs;
 
     // Set select options
     document.querySelector('select[name="page_scaling"]').value = configuration.pageScaling;


### PR DESCRIPTION
Being able to insert an adjustable number of
flyleafs is important for generating books with
even signature counts