### PR TITLE
Spine Lines: Take 2! 

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,10 @@
                 </span> 
                 <span class="row"> <label>Add Cutlines <input type="checkbox" name="cutmarks"></label>
                     <span data-balloon-length="medium" aria-label="Adds cutting guidelines" data-balloon-pos="up">ℹ️</span>
+                
+                </span>
+                <span class="row"> <label>Add PDF bounds indicators (spine) <input type="checkbox" name="pdf_edge_marks"></label>
+                    <span data-balloon-length="medium" aria-label="Puts small marks on the outermost folio of the signatures indicating the top and bottom of the PDF" data-balloon-pos="up">ℹ️</span>
                 </span> 
 
                 <span class="row">

--- a/src/book.js
+++ b/src/book.js
@@ -53,6 +53,7 @@ export class Book {
         this.page_positioning = configuration.pagePositioning;
         this.flyleafs = configuration.flyleafs;
         this.cropmarks = configuration.cropMarks;
+        this.pdfEdgeMarks = configuration.pdfEdgeMarks;
         this.cutmarks = configuration.cutMarks;
         this.format = configuration.sigFormat;
         if (configuration.sigFormat === "standardsig") {
@@ -208,7 +209,7 @@ export class Book {
                 } else {
                     this.book.createsigconfig();
                 }
-                this.rearrangedpages = this.book.pagelist;
+                this.rearrangedpages = this.book.pagelistdetails;
                 break;
             case 'a9_3_3_4':
             case 'a10_6_10s':
@@ -220,7 +221,7 @@ export class Book {
                 this.book = new WackyImposition(this.orderedpages, this.duplex, this.format, this.pack_pages);
                 break;
         }
-        // dracula
+
         console.log("Created pages for : ",this.book);
         let dim = this.calculate_dimensions();
 
@@ -266,12 +267,12 @@ export class Book {
             const [aggregatePdf1, embeddedPages1] = (generateAggregate && !this.duplex) ? await this.embedPagesInNewPdf(this.managedDoc, pdf1PageNumbers) : [null, null];
             const forLoop = async _ => {
                 for (let i = 0; i < this.rearrangedpages.length; i++) {
-                    let page = this.rearrangedpages[i];
+                    let signature = this.rearrangedpages[i];
                     await this.createsignatures({
                         embeddedPages: (generateAggregate) ? [embeddedPages0, embeddedPages1] : null,
                         aggregatePdfs: (generateAggregate) ? [aggregatePdf0, aggregatePdf1] : null,
-                        pageIndexes: page, 
-                        id: (generateSignatures) ? `${filename}${i}` : null,
+                        pageIndexDetails: signature, 
+                        id: (generateSignatures) ? `signature${i}` : null,
                         isDuplex: this.duplex,
                         fileList: this.filelist
                     });
@@ -378,7 +379,7 @@ export class Book {
      *
      * @param config - object /w the following parameters:
      *      - outname : name of pdf added to ongoing zip file. Ex: 'signature1duplex.pdf' (or null if no signature file needed)
-     *      - pageList : indicies of pages to assemble. Ex: [12, 11, 10, 13, 14, 9, 8, 15]
+     *      - pageList : REBECCA TODO
      *      - back : is 'back' of page  (boolean)
      *      - alt : alternate pages (boolean)
      *      - destPdf : PDF to write to, in addition to PDF created w/ `outname` (or null)
@@ -392,9 +393,9 @@ export class Book {
         const back = config.back;
         let filteredList = [];
         let blankIndices = [];
-        pagelist.forEach((page, i) => {
-            if (page != 'b') {
-                filteredList.push(page);
+        pagelist.forEach((pageInfo, i) => {
+            if (pageInfo != 'b') {
+                filteredList.push(pageInfo.info);
             } else {
                 blankIndices.push(i);
             }
@@ -419,8 +420,10 @@ export class Book {
         let positions = this.calculatelayout(alt_folio);
 
         let side2flag = back;
-    
+        console.log("Rebecca : wripages : pdfEdgeMarks " + this.pdfEdgeMarks)
+
         while (block_end <= pagelist.length) {
+            let sigDetails = config.pageList.slice(block_start, block_end)
             if (printAggregate) {
                 this.draw_block_onto_page({
                     outPDF: config.destPdf,
@@ -428,8 +431,10 @@ export class Book {
                     block_start: block_start,
                     block_end: block_end,
                     papersize: this.papersize,
+                    sigDetails: sigDetails,
                     positions: positions,
                     cropmarks: this.cropmarks,
+                    pdfEdgeMarks: this.pdfEdgeMarks,
                     cutmarks: this.cutmarks,
                     alt: config.alt,
                     side2flag: side2flag
@@ -441,9 +446,11 @@ export class Book {
                     embeddedPages: embeddedPages,
                     block_start: block_start,
                     block_end: block_end,
+                    sigDetails: sigDetails,
                     papersize: this.papersize,
                     positions: positions,
                     cropmarks: this.cropmarks,
+                    pdfEdgeMarks: this.pdfEdgeMarks,
                     cutmarks: this.cutmarks,
                     alt: config.alt,
                     side2flag: side2flag
@@ -459,12 +466,14 @@ export class Book {
     }
 
     draw_block_onto_page(config) {
+        const sigDetails = config.sigDetails;
         const block_start = config.block_start;
         const block_end = config.block_end;
         const papersize = config.papersize;
         const outPDF = config.outPDF;
         const positions = config.positions;
         const cropmarks = config.cropmarks;
+        const pdfEdgeMarks = config.pdfEdgeMarks;
         const cutmarks = config.cutmarks;
         const alt = config.alt;
         let side2flag = config.side2flag;
@@ -481,6 +490,14 @@ export class Book {
                 currPage.drawPage(page, { y: pos.y, x: pos.x, xScale: pos.sx, yScale: pos.sy, rotate: degrees(rot) });
             }
         });
+        block.forEach((page, i) => {
+            if (sigDetails[i].isSigStart || sigDetails[i].isSigEnd) {
+                console.log("Rebecca pdfEdgeMarks "+pdfEdgeMarks)
+                if (pdfEdgeMarks) {
+                    this.draw_spine_marks(currPage, sigDetails[i], positions[i])
+                }
+            }
+        });
         if (cropmarks) {
             this.draw_cropmarks(currPage, side2flag);
         }
@@ -491,6 +508,60 @@ export class Book {
             side2flag = !side2flag;
         }
         return side2flag;
+    }
+
+    /*
+     * @param curPage - PDFPage
+     * @param sigDetails - object w/ {info (page # or 'b'), isSigStart (boolean), isSigEnd (boolean)}
+     * @param position - object w/ {rotation (degrees), sx, sy, x, y}
+     */
+    draw_spine_marks(curPage, sigDetails, position) {
+        console.log("Rebecca ==========[isSigStart: "+sigDetails.isSigStart)
+        console.log("Rebecca I see sigDetails ", sigDetails)
+        console.log("Rebecca I see position ", position)
+        let w = 5;
+        if (position.rotation == 0) {
+            console.log(" --> draw this: ",{
+              start: { 
+                x: (sigDetails.isSigStart) ? position.spineMarkTop[0] - w/2: position.spineMarkBottom[0] - w/2, 
+                y: ((sigDetails.isSigStart) ? position.spineMarkTop[1] : position.spineMarkBottom[1] )
+                },
+              end: { 
+                x: (sigDetails.isSigStart) ? position.spineMarkTop[0] + w/2: position.spineMarkBottom[0]+ w/2, 
+                y: ((sigDetails.isSigStart) ? position.spineMarkTop[1] : position.spineMarkBottom[1] ) 
+                },
+              thickness: 0.5,
+              color: rgb(0,0,0),
+              opacity: 1,
+            })
+            curPage.drawLine({
+              start: { 
+                x: (sigDetails.isSigStart) ? position.spineMarkTop[0] - w/2: position.spineMarkBottom[0] - w/2, 
+                y: ((sigDetails.isSigStart) ? position.spineMarkTop[1] : position.spineMarkBottom[1] )
+                },
+              end: { 
+                x: (sigDetails.isSigStart) ? position.spineMarkTop[0] + w/2: position.spineMarkBottom[0]+ w/2, 
+                y: ((sigDetails.isSigStart) ? position.spineMarkTop[1] : position.spineMarkBottom[1] ) 
+                },
+              thickness: 0.5,
+              color: rgb(0,0,0),
+              opacity: 1,
+            })
+        } else {
+            curPage.drawLine({
+              start: { 
+                x: (sigDetails.isSigStart) ? position.spineMarkTop[0] : position.spineMarkBottom[0], 
+                y: ((sigDetails.isSigStart) ? position.spineMarkTop[1] - w/2: position.spineMarkBottom[1] ) - w/2
+                },
+              end: { 
+                x: (sigDetails.isSigStart) ? position.spineMarkTop[0] : position.spineMarkBottom[0], 
+                y: ((sigDetails.isSigStart) ? position.spineMarkTop[1]  + w/2: position.spineMarkBottom[1] ) + w/2
+                },
+              thickness: 0.25,
+              color: rgb(0,0,0),
+              opacity: 1,
+            })
+        }
     }
 
     draw_cropmarks(currPage, side2flag) {
@@ -734,25 +805,37 @@ export class Book {
                 let isLeftPage = j % 2 == 0; //page on 'left' side of open book
                 let x = (j * cellWidth) + ((isLeftPage) ? xForeEdgeShift : xBindingShift);
                 let y = (i * cellHeight) + yBottomShift;
+                let spineMarkTop = [(j * cellWidth), ((i + 1) * cellHeight) - yTopShift]
+                let spineMarkBottom = [((j+1) * cellWidth), (i * cellHeight) + yBottomShift]
 
                 if (col == -180) { // upside-down page
                     isLeftPage = j % 2 == 1; //page on 'left' (right side on screen)
                     y = (i + 1) * cellHeight - yBottomShift;
                     x = (j + 1) * cellWidth - ((isLeftPage) ? xForeEdgeShift : xBindingShift);
+                    spineMarkTop = [(j + 1) * cellWidth, (i + 1) * cellHeight];
+                    spineMarkBottom = [(j + 1) * cellWidth, i * cellHeight];
 
                 } else if (col == 90) {   // 'top' of page is on left, right side of screen
                     isLeftPage = i % 2 == 0; // page is on 'left' (top side of screen)
                     x = (1 + j) * cellHeight - yBottomShift;
                     y = i * cellWidth + ((isLeftPage) ? xBindingShift : xForeEdgeShift);
+                    spineMarkTop = [(1 + j) * cellHeight, i * cellWidth];
+                    spineMarkBottom = [j * cellHeight, i * cellWidth];
 
                 } else if (col == -90) {  // 'top' of page is on the right, left sight of screen
                     isLeftPage = i % 2 == 1; // page is on 'left' (bottom side of screen)
                     x = j * cellHeight + yBottomShift;
                     y = (1+i) * cellWidth - ((isLeftPage) ? xForeEdgeShift : xBindingShift);
+                    spineMarkTop = [(j+1) * cellHeight - yTopShift, (isLeftPage ? i : i+1) * cellWidth];
+                    spineMarkBottom = [j * cellHeight + yBottomShift, (isLeftPage ? i : i+1) * cellWidth];
                 }
 
                 console.log(">> (", i, ",",j,")[",col,"] : [",x,", ",y,"] :: [xForeEdgeShift: ",xForeEdgeShift,"][xBindingShift: ",xBindingShift,"]");
-                positions.push({rotation: col, sx: l.pdfScale[0], sy: l.pdfScale[1], x: x, y: y});
+                positions.push({rotation: col, sx: l.pdfScale[0], sy: l.pdfScale[1], x: x, y: y,
+                    spineMarkTop: spineMarkTop, 
+                    spineMarkBottom: spineMarkBottom,
+                    isLeftPage: isLeftPage
+                });
             });
         });
         console.log("And in the end of it all, (calculatelayout) we get: ",positions);
@@ -763,7 +846,7 @@ export class Book {
      * PDF builder base function for Classic (non-Wacky) layouts. Called by [createoutputfiles]
      *
      * @param config - object w/ the following parameters:
-     *    - pageIndexes : a nested list of original source document page numbers ordered for layout. ( [0] for duplex & front, [1] for backs -- value is null if no aggregate printing enabled). Ex: [[4, 3, 2, 5, 6, 1, 0, 7]]
+     *    - pageIndexDetails : a nested list of original source document page numbers ordered for layout. ( [0] for duplex & front, [1] for backs -- value is null if no aggregate printing enabled). Ex: [[4, 3, 2, 5, 6, 1, 0, 7]]
      *    - aggregatePdfs : list of destination PDF(s_ for aggregated content ( [0] for duplex & front, [1] for backs -- value is null if no aggregate printing enabled)
      *    - embeddedPages : list of lists of embedded pages from source document ( [0] for duplex & front, [1] for backs -- value is null if no aggregate printing enabled)
      *    - id : string dentifier for signature file name (null if no signature files to be generated)
@@ -773,7 +856,8 @@ export class Book {
     async createsignatures(config) {
         const printAggregate = config.aggregatePdfs != null;
         const printSignatures = config.id != null;
-        const pages = config.pageIndexes;
+        const pages = config.pageIndexDetails;
+        console.log("Rebecca : createsignatures : "+pages)
         //      duplex printers print both sides of the sheet, 
         if (config.isDuplex) {
             let outduplex = (printSignatures) ? config.id + 'duplex' + '.pdf' : null;

--- a/src/models/configuration.js
+++ b/src/models/configuration.js
@@ -65,6 +65,7 @@ export const schema = z.object({
     pageLayout,
     cropMarks: urlSafe(coercedBoolean).default(false),
     cutMarks: urlSafe(coercedBoolean).default(false),
+    pdfEdgeMarks: urlSafe(coercedBoolean).default(false),
     pageScaling,
     pagePositioning,
     mainForeEdgePaddingPt: urlSafe(z.coerce.number()).default(0),

--- a/src/signatures.js
+++ b/src/signatures.js
@@ -15,7 +15,7 @@ export class Signatures {
 		this.per_sheet = per_sheet || 4; // pages per sheet - default is 4.
 		this.duplexrotate = duplexrotate || false;
 
-		this.pagelist = [];
+		this.pagelistdetails = [];
 
 		this.sheets = Math.ceil(pages.length / this.per_sheet);
 
@@ -41,7 +41,7 @@ export class Signatures {
 			let blanks = new Array(diff).fill('b');
 			this.inputpagelist.push(...blanks);
 		}
-		this.pagelist = [];
+		this.pagelistdetails = [];
 		this.signaturepagelists = [];
 
 		this.splitpagelist();
@@ -49,7 +49,7 @@ export class Signatures {
 	createsigconfig() {
 
 		this.sigconfig = this.generatesignatureindex();
-		this.pagelist = [];
+		this.pagelistdetails = [];
 		this.signaturepagelists = [];
 
 		this.splitpagelist();
@@ -78,11 +78,11 @@ export class Signatures {
 
 		//      Use the booklet class for each signature
 		this.signaturepagelists.forEach(pagerange => {
-			let pagelist = this.booklet(pagerange, this.duplex, this.per_sheet, this.duplexrotate);
-			newsigs.push(pagelist);
+			let pagelistdetails = this.booklet(pagerange, this.duplex, this.per_sheet, this.duplexrotate);
+			newsigs.push(pagelistdetails);
 		});
 
-		this.pagelist = newsigs;
+		this.pagelistdetails = newsigs;
 	}
 	generatesignatureindex() {
 
@@ -117,7 +117,7 @@ export class Signatures {
 	}
 
 	booklet(pages, duplex, per_sheet, duplexrotate) {
-        let pagelist = duplex ? [[]] : [[], []];
+        let pagelistdetails = duplex ? [[]] : [[], []];
         let sheets = 1;
 		const {front, rotate, back} = BOOKLET_LAYOUTS[per_sheet];
 
@@ -142,14 +142,22 @@ export class Signatures {
 
             front_config.forEach((pnum) => {
                 let page = block[pnum - 1]; //page layouts are 1-indexed, not 0-index
-                pagelist[0].push(page);
+                pagelistdetails[0].push({
+                    info: page,
+                    isSigStart:front_start == 0 && pnum == 1, 
+                    isSigEnd: front_start == 0 && pnum == block.length
+                });
             });
 
             const backlist = this.duplex ? 0 : 1;
 
             back_config.forEach((pnum) => {
                 let page = block[pnum - 1];
-                pagelist[backlist].push(page);
+                pagelistdetails[backlist].push({
+                    info: page,
+                    isSigStart:front_start == 0 && pnum == 1, 
+                    isSigEnd: front_start == 0 && pnum == block.length
+                });
             });
 
             // Update all our counters
@@ -159,6 +167,6 @@ export class Signatures {
             back_end += pageblock;
         }
 
-		return pagelist;
+		return pagelistdetails;
     }
 }

--- a/src/utils/formUtils.js
+++ b/src/utils/formUtils.js
@@ -22,6 +22,7 @@ const fromFormToConfiguration = (form) =>
         paperRotation90: form.has("paper_rotation_90"),
         pageLayout: form.get("pagelayout"),
         cropMarks: form.has("cropmarks"),
+        pdfEdgeMarks: form.has("pdf_edge_marks"),
         cutMarks: form.has("cutmarks"),
         pageScaling: form.get("page_scaling"),
         pagePositioning: form.get("page_positioning"),

--- a/src/utils/renderUtils.js
+++ b/src/utils/renderUtils.js
@@ -18,7 +18,7 @@ export function renderInfoBox(book) {
     if (book.book == null || book.book == undefined)
         return
 
-    const outputPages = book.book.pagelist.reduce((acc, list) => {
+    const outputPages = book.book.pagelistdetails.reduce((acc, list) => {
         list.forEach((sublist) => (acc += (sublist.length ? sublist.length : 1)));
         return acc;
     }, 0);
@@ -165,6 +165,10 @@ export function renderFormFromSettings(configuration) {
 
     if (configuration.cropMarks) {
         document.querySelector("input[name='cropmarks']").checked = true;
+    }
+
+    if (configuration.pdfEdgeMarks) {
+        document.querySelector("input[name='pdf_edge_marks']").checked = true;
     }
 
     if (configuration.cutMarks) {


### PR DESCRIPTION
Adds option to draw marks on the outermost folio of each signature at the top & bottom of the PDF, as it's positioned on the page.

This is useful for people adding padding via the Imposer
This is also the groundwork for adding signature ordering marks (will add in followup PR, will be much easier after this)


New enabling UI

<img width="413" alt="Screen Shot 2024-02-03 at 12 06 15 AM" src="https://github.com/momijizukamori/bookbinder-js/assets/1319240/3dc86bfd-37fd-4896-98ec-a3e90bafdc49">


Samples of what they look like on the docs:

<img width="465" alt="Screen Shot 2024-02-03 at 12 05 31 AM" src="https://github.com/momijizukamori/bookbinder-js/assets/1319240/61eaeda9-bb15-40e4-9cb6-4188d586d821">
<img width="468" alt="Screen Shot 2024-02-03 at 12 05 11 AM" src="https://github.com/momijizukamori/bookbinder-js/assets/1319240/61552d44-a912-42a0-ba78-7b2b5b293887">
<img width="461" alt="Screen Shot 2024-02-03 at 12 04 54 AM" src="https://github.com/momijizukamori/bookbinder-js/assets/1319240/7d00601c-7265-43b5-b05b-a29ba8af028e">
<img width="482" alt="Screen Shot 2024-02-03 at 12 04 33 AM" src="https://github.com/momijizukamori/bookbinder-js/assets/1319240/17b893c8-bf19-4f30-83b6-3a355a5b29a6">
