### PR TITLE
Improve file naming and pathing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookbinder",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "An app to rearrange PDF pages for printing for bookbinding",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Original pdf name will now correctly regex replace. The previous regex was lacking the g flag causing it to not remove the pdf extension if a space or comma was present.

File name conversion now replaces space, commas, and hypens to underscores.

Signature files will be placed into a signatures/ folder.

NEW:
<img width="922" alt="Screenshot 2024-02-19 at 12 48 17 PM" src="https://github.com/momijizukamori/bookbinder-js/assets/18414941/59329535-d2f7-4f3e-9f38-1d88bc76459a">

OLD:
<img width="922" alt="Screenshot 2024-02-19 at 12 52 27 PM" src="https://github.com/momijizukamori/bookbinder-js/assets/18414941/63ace6f4-734c-4140-af89-0af6be9e60ad">


