### PR TITLE
adding docker functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,5 +111,11 @@ docs/*.aux
 # Mac's Finder's DS_Store files
 **/.DS_Store
 
+# Jetbrains IDEs' folders
+.idea
+
+# Docker stuff
+compose.override.yaml
+
 # Firefox debug storage
 tmp

--- a/README.md
+++ b/README.md
@@ -51,3 +51,33 @@ In the [`/docs`](/docs) directory:
 
 Snapshot of layout proof summary as of 2022-08-14
 ![Snapshot of layout proof summary 2022-08-14](/docs/examples_summary_snapshot_2022_08_14.png)
+
+## Containerization
+
+### Production
+
+We added an easy compose.yaml for building and hosting this applications' files using nginx.
+
+This nginx does not open any ports, expects to be proxied by some other external web server and may be omitted if not needed.
+
+If you require this nginx to open a port, feel free to add your own (docker-)compose.override.yaml, where you would open ports as needed, like so
+
+```yaml
+services:
+  bookbinder-nginx:
+    ports:
+      - '80:80'
+```
+
+### Development
+
+If you need to run bookbinder-js in development mode, feel free to create your compose.override.yaml and overwrite the startup command - `npm run build` by default - and create the container with host network mode, which would look like this
+
+```yaml
+services:
+  bookbinder-app:
+    # environment:
+    #   BASE: "http://localhost" <-- can be adjusted to your environment
+    network_mode: 'host'
+    command: bash -c "cd /app && npm install && npm run dev"
+```

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,14 @@
+services:
+  bookbinder-app:
+    # environment:
+    #   BASE: 'https://momijizukamori.github.io/bookbinder-js/' <-- is default in vite.config.js
+    image: node:24
+    volumes:
+      - .:/app
+    command: bash -c "cd /app && npm install && npm run build"
+
+  bookbinder-nginx:
+    image: nginx
+    restart: unless-stopped
+    volumes:
+      - ./dist:/usr/share/nginx/html

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,7 @@ import version from 'vite-plugin-package-version';
 import injectHTML from 'vite-plugin-html-inject';
 
 export default defineConfig({
-  base: 'https://momijizukamori.github.io/bookbinder-js/',
+  base: process.env.BASE || 'https://momijizukamori.github.io/bookbinder-js/',
   test: {
     environment: 'jsdom',
   },


### PR DESCRIPTION
Hey :wave: 

As I was hosting bookbinder, I thought I could share a possible docker setup with you.

This setup creates the bookbinder app and proposes proxying it with nginx, nothing more.
Everything is easily extendable using `compose.override.yaml` and overwriting the base URL as necessary.

In this example, node v.24 is being used, which is what I am guessing why linting fails at the moment.

Let me know what you think, we could also change the node version or whatever...
Let's talk about it!

Thanks for this nice project,
See you around :heart: 