### PR TITLE
Allow loading PDFs that use permission-only encryption

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,6 +39,8 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
+        env:
+          BASE: /bookbinder-js/
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 public/old/*
+public/matcha.css

--- a/src/book.js
+++ b/src/book.js
@@ -137,7 +137,7 @@ export class Book {
   async openpdf(file) {
     this.inputpdf = file.name;
     this.input = await file.arrayBuffer(); //fs.readFileSync(filepath);
-    this.currentdoc = await PDFDocument.load(this.input);
+    this.currentdoc = await PDFDocument.load(this.input, { ignoreEncryption: true });
     this.fixBlankPages();
   }
 


### PR DESCRIPTION
`PDFDocument.load` rejects any file with an `/Encrypt` dict in the trailer, even when the user password is empty and the encryption is just there to block copy/edit/annotate.

I hit this trying to process the [Roland S-1 owner's manual](https://www.roland.com/global/support/by_product/s-1/owners_manuals/), which has encryption flags but no password. It throws `EncryptedPDFError` at `src/book.js:140` and never gets past load.

Fix is to pass `{ ignoreEncryption: true }` to `PDFDocument.load` in `openpdf`, which is what pdf-lib's own error message tells you to do.

Happy to dig in further or take on related work if useful.